### PR TITLE
Feature/GeneralizedTypeSystemDefinition

### DIFF
--- a/jembatan/analyzers/simple.py
+++ b/jembatan/analyzers/simple.py
@@ -73,7 +73,7 @@ class RegexSplitAnnotator(AnalysisFunction):
 
             if not matches:
                 # no split found so make the whole window paragraph
-                span = Span(begin=window.begin+0, end=window.begin+len(spndx.content))
+                span = Span(begin=window.begin+0, end=window.begin+len(spndx.content_string))
                 annotation = self.annotation_type(begin=span.begin, end=span.end)
                 annotations.append(annotation)
             else:

--- a/jembatan/analyzers/spacy.py
+++ b/jembatan/analyzers/spacy.py
@@ -7,7 +7,6 @@ import functools
 from enum import auto, Flag
 from jembatan.core.spandex import (Span, Spandex)
 from jembatan.core.af import AnalysisFunction
-from jembatan.typesys import AnnotationRef
 from jembatan.typesys.chunking import NounChunk, Entity
 from jembatan.typesys.segmentation import (Document, Sentence, Token)
 from jembatan.typesys.syntax import (DependencyEdge, DependencyNode, DependencyParse)
@@ -194,19 +193,17 @@ class SpacyToSpandexUtils:
                 for (tok, spacy_tok) in word_toks:
                     headtok = all_toks[spacy_tok.head.i]
                     head_node = span_to_nodes[headtok.span]
-                    head_ref = AnnotationRef(obj=head_node)
                     child_span = tok.span
                     child_node = span_to_nodes[child_span]
-                    child_ref = AnnotationRef(obj=child_node)
 
                     # get span for full dependency
                     depspan = Span(begin=min(tok.begin, headtok.begin),
                                    end=max(tok.end, headtok.end))
                     # Build edges
-                    depedge = DependencyEdge(label=spacy_tok.dep_, head_ref=head_ref, child_ref=child_ref)
+                    depedge = DependencyEdge(label=spacy_tok.dep_, head=head_node, child=child_node)
                     depedge.span = depspan
                     child_node.head_edge = depedge
-                    head_node.add_child_edge(depedge)
+                    head_node.child_edges.append(depedge)
                     if headtok.span not in depnode_spans:
                         depnodes.append(head_node)
                         depnode_spans.add(head_node.span)

--- a/jembatan/analyzers/spacy.py
+++ b/jembatan/analyzers/spacy.py
@@ -292,7 +292,6 @@ class SpacyAnalyzer(AnalysisFunction):
         else:
             # process over windows
             for window in spndx.select(self.window_type):
-                print(window)
                 window_text = spndx.spanned_text(window)
                 spacy_doc = self.spacy_pipeline(window_text)
                 SpacyToSpandexUtils.spacy_to_spandex(spacy_doc, spndx, annotation_layers, window)

--- a/jembatan/core/spandex/__init__.py
+++ b/jembatan/core/spandex/__init__.py
@@ -1,5 +1,5 @@
 from collections import namedtuple
-from jembatan.core.spandex.typesys_base import Span, Annotation
+from jembatan.core.spandex.typesys_base import Span, Annotation, AnnotationScope, SpannedAnnotation
 from pathlib import Path
 from typing import ClassVar, Iterable, Optional, Union
 
@@ -137,7 +137,7 @@ class Spandex(object):
         return self.viewops.create_view(self, viewname, content_string=content_string, content_mime=content_mime)
 
     def compute_keys(self, layer_annotations: Iterable[Annotation]):
-        return [a.begin for a in layer_annotations]
+        return [(a.scope, a.begin) if isinstance(a, SpannedAnnotation) else (a.scope, None) for a in layer_annotations]
 
     def spanned_text(self, span: Span):
         """
@@ -174,8 +174,8 @@ class Spandex(object):
         layer = self.aliases.get(layer, layer)
         if layer not in self.annotation_keys:
             return []
-        begin = bisect.bisect_left(self.annotation_keys[layer], span.begin)
-        end = bisect.bisect_left(self.annotation_keys[layer], span.end)
+        begin = bisect.bisect_left(self.annotation_keys[layer], (AnnotationScope.SPAN, span.begin))
+        end = bisect.bisect_left(self.annotation_keys[layer], (AnnotationScope.SPAN, span.end))
         return self.annotations[layer][begin:end]
 
     def select_preceding(self, layer: ClassVar[Annotation], span: Span, count: int=None) -> Iterable[Annotation]:

--- a/jembatan/core/spandex/__init__.py
+++ b/jembatan/core/spandex/__init__.py
@@ -26,7 +26,7 @@ class DefaultViewOps(object):
 
         return view
 
-    def create_view(self, spndx, viewname: str, content_string: str=None, content_mime: str=None):
+    def create_view(self, spndx: "Spandex", viewname: str, content_string: str=None, content_mime: str=None):
         root = spndx if not spndx.root else spndx.root
 
         new_view_spndx = Spandex(content_string=content_string, content_mime=content_mime, root=root, viewname=viewname)
@@ -124,6 +124,7 @@ class Spandex(object):
             view = self.get_view(viewname)
         except KeyError:
             view.create_view(viewname)
+        return view
 
     def __getitem__(self, viewname: str):
         return self.get_view(viewname)

--- a/jembatan/core/spandex/__init__.py
+++ b/jembatan/core/spandex/__init__.py
@@ -70,7 +70,6 @@ class Spandex(object):
         self._content_string = content_string
         self._content_mime = content_mime
         self._annotations = {}
-        self._view_annotations = {}
         self.annotation_keys = {}
         self.aliases = {}
         self.viewops = DefaultViewOps()
@@ -117,10 +116,6 @@ class Spandex(object):
     def annotations(self):
         return self._annotations
 
-    @property
-    def view_annotations(self):
-        return self._view_annotations
-
     def get_view(self, viewname: str):
         return self.viewops.get_view(self, viewname)
 
@@ -137,7 +132,7 @@ class Spandex(object):
         return self.viewops.create_view(self, viewname, content_string=content_string, content_mime=content_mime)
 
     def compute_keys(self, layer_annotations: Iterable[Annotation]):
-        return [(a.scope, a.begin) if isinstance(a, SpannedAnnotation) else (a.scope, None) for a in layer_annotations]
+        return [a.index_key for a in layer_annotations]
 
     def spanned_text(self, span: Span):
         """

--- a/jembatan/core/spandex/json.py
+++ b/jembatan/core/spandex/json.py
@@ -23,7 +23,8 @@ class SpandexJsonEncoder(json.JSONEncoder):
                     "layers": layers,
                     "content_string": view.content_string,
                     "content_mime": view.content_mime,
-                    "_type": "spandex_view"
+                    "_type": "spandex_view",
+                    "view_annotations": self.default(view.view_annotations)
                 }
                 for layer_class, annotation_objs in view.annotations.items():
                     layer_name = '.'.join([layer_class.__module__, layer_class.__name__])
@@ -49,11 +50,9 @@ class SpandexJsonEncoder(json.JSONEncoder):
                     '_type': 'annotation_field',
                     'name': f,
                     'value': self.default(getattr(obj, f))
-                } for f in obj.__dataclass_fields__ if f not in ['id'] #['id', 'begin', 'end']
+                } for f in obj.__dataclass_fields__ if f not in ['id']
             ]
             annotation_obj['id'] = str(obj.id)
-            #annotation_obj['begin'] = int(obj.begin)
-            #annotation_obj['end'] = int(obj.end)
 
             return annotation_obj
         elif isinstance(obj, jemtypes.AnnotationRef):
@@ -70,6 +69,8 @@ class SpandexJsonEncoder(json.JSONEncoder):
             return obj
         elif isinstance(obj, numbers.Number):
             return float(obj)
+        elif isinstance(obj, dict):
+            return {k: self.default(v) for k, v in obj.items()}
         elif obj is None:
             return obj
         return json.JSONEncoder.default(self, obj)

--- a/jembatan/core/spandex/json.py
+++ b/jembatan/core/spandex/json.py
@@ -1,7 +1,8 @@
 from collections import defaultdict
-from collections.abc import Sequence
 from jembatan.core import spandex
+from typing import Mapping, Sequence
 
+import bson
 import importlib
 import jembatan.typesys as jemtypes
 import json
@@ -9,10 +10,40 @@ import numbers
 import uuid
 
 
-
 class SpandexJsonEncoder(json.JSONEncoder):
 
+    def encode_annotation_id(self, id_):
+        return str(id_)
+
+    def encode_annotation(self, obj, inside_field):
+            if inside_field:
+                ref = jemtypes.AnnotationRef(obj=obj) if obj is not None else obj
+                return self.encode_obj(ref, inside_field=True)
+            else:
+                annotation_obj = {}
+                annotation_obj['_type'] = "spandex_annotation"
+                annotation_obj['_annotation_type'] = f"{obj.__class__.__module__}.{obj.__class__.__name__}"
+                annotation_obj['_fields'] = [
+                    self.encode_annotation_field(getattr(obj, fname), f)
+                    for fname, f in obj.__dataclass_fields__.items()
+                ]
+                annotation_obj['id'] = self.encode_annotation_id(obj.id)
+                annotation_obj['scope'] = self.encode_obj(obj.scope)
+
+                return annotation_obj
+
+    def encode_annotation_field(self, obj, field):
+        encoded_value = self.encode_obj(obj, inside_field=True)
+
+        return {
+            'name': field.name,
+            'value': encoded_value
+        }
+
     def default(self, obj):
+        return self.encode_obj(obj)
+
+    def encode_obj(self, obj, inside_field=False):
         if isinstance(obj, spandex.Spandex):
 
             spandex_obj = {"_type": "spandex", 'views': []}
@@ -24,15 +55,11 @@ class SpandexJsonEncoder(json.JSONEncoder):
                     "layers": layers,
                     "content_string": view.content_string,
                     "content_mime": view.content_mime,
-                    "_type": "spandex_view",
-                    "view_annotations": {
-                        "_type": "spandex_view_annotations",
-                        "annotations": self.default(view.view_annotations)
-                    }
+                    "_type": "spandex_view"
                 }
                 for layer_class, annotation_objs in view.annotations.items():
                     layer_name = '.'.join([layer_class.__module__, layer_class.__name__])
-                    annotations = [self.default(annotation) for annotation in annotation_objs]
+                    annotations = [self.encode_obj(annotation, inside_field) for annotation in annotation_objs]
                     layer_obj = {
                         'name': layer_name,
                         'annotations': annotations,
@@ -44,42 +71,37 @@ class SpandexJsonEncoder(json.JSONEncoder):
 
         elif isinstance(obj, Sequence) and not isinstance(obj, str):
             # handle non-string sequences (like lists or iterators)
-            return [self.default(i) for i in obj]
+            return [self.encode_obj(i, inside_field) for i in obj]
+        elif isinstance(obj, Mapping):
+            # convert fields that are mappings / dictionaries into JSON dictionaries
+            return {
+                self.encode_obj(k, inside_field): self.encode_obj(k, inside_field) for k, v in obj.items()
+            }
+            return [self.encode_obj(i, inside_field) for i in obj]
         elif isinstance(obj, jemtypes.AnnotationScope):
             return str(obj.to_json())
-        elif isinstance(obj, jemtypes.SpannedAnnotation):
-            annotation_obj = {}
-            annotation_obj['_type'] = "spandex_annotation"
-            annotation_obj['_annotation_type'] = f"{obj.__class__.__module__}.{obj.__class__.__name__}"
-            annotation_obj['_fields'] = [
-                {
-                    '_type': 'annotation_field',
-                    'name': f,
-                    'value': self.default(getattr(obj, f))
-                } for f in obj.__dataclass_fields__ if f not in ['id', 'scope']
-            ]
-            annotation_obj['id'] = str(obj.id)
-            annotation_obj['scope'] = obj.scope.value
-
-            return annotation_obj
+        elif isinstance(obj, jemtypes.Annotation):
+            return self.encode_annotation(obj, inside_field)
         elif isinstance(obj, jemtypes.AnnotationRef):
-            return {
-                "ref": {
-                    "id": self.default(obj.obj.id if obj.obj else None)
-                },
-                "_type": "annotation_ref",
-                "_annotation_type": f"{obj.obj.__class__.__module__}.{obj.obj.__class__.__name__}",
-            }
-        elif isinstance(obj, uuid.UUID):
-            return str(obj)
+            if obj.obj is None:
+                return None
+            else:
+                return {
+                    "ref": {
+                        "id": self.encode_obj((obj.obj.id if obj.obj else None), inside_field)
+                    },
+                    "_type": "annotation_ref",
+                    "_annotation_type": f"{obj.obj.__class__.__module__}.{obj.obj.__class__.__name__}",
+                }
         elif isinstance(obj, str):
             return obj
         elif isinstance(obj, numbers.Number):
             return float(obj)
         elif isinstance(obj, dict):
-            return {k: self.default(v) for k, v in obj.items()}
+            return {k: self.encode_obj(v, inside_field) for k, v in obj.items()}
         elif obj is None:
             return obj
+
         return json.JSONEncoder.default(self, obj)
 
 
@@ -98,12 +120,16 @@ class SpandexJsonDecoder(json.JSONDecoder):
         return self.object_hook(obj)
 
     def object_hook(self, obj):
+        return self.decode_obj(obj, inside_field=False)
+
+    def decode_obj(self, obj, inside_field=False):
         if isinstance(obj, (str, int, float, bool)) or obj is None:
             # simply return basic types
             return obj
         elif isinstance(obj, Sequence):
             # turn non-string Sequences into lists.
-            return [self.object_hook(i) for i in obj]
+            seq = [self.decode_obj(i, inside_field) for i in obj]
+            return seq
         elif '_type' not in obj:
             # if it's a dictionary without a '_type', return as is
             return obj
@@ -135,16 +161,12 @@ class SpandexJsonDecoder(json.JSONDecoder):
                     module_name, class_name = layer_name.rsplit('.', 1)
                     module = importlib.import_module(module_name)
                     for annotation_obj in layer['annotations']:
-                        annotation = self.object_hook(annotation_obj)
-                        annotation_type = getattr(module, class_name)
-                        self.layer_registry[layer_name][annotation.id] = annotation
+                        if annotation_obj:
+                            annotation = self.decode_obj(annotation_obj)
+                            annotation_type = getattr(module, class_name)
+                            self.layer_registry[layer_name][annotation.id] = annotation
 
                     view.add_layer(annotation_type, self.layer_registry[layer_name].values())
-
-                view_annotations_obj = view_obj['view_annotations']
-                print("VIEW_ANNOTS", view_annotations_obj)
-                print("VIEW_ANNOTS_THING", self.object_hook(view_annotations_obj))
-                #view.view_annotations = 
 
             # reset layer registry
             self.reset_layers()
@@ -158,12 +180,24 @@ class SpandexJsonDecoder(json.JSONDecoder):
             module_name, class_name = layer_name.rsplit('.', 1)
             module = importlib.import_module(module_name)
             annotation_type = getattr(module, class_name)
-            annotation_id = uuid.UUID(obj['id'])
+            annotation_id = obj.get('id', None)
+            """
+            id_type = obj_id.get('_id_type', None)
+            id_val = obj_id.get('_value', None)
+
+            if id_type == "uuid":
+                    annotation_id = uuid.UUID(id_val)
+            elif id_type == "objectId":
+                    annotation_id = bson.ObjectId(id_val)
+            else:
+                annotation_id = id_val
+            """
             if annotation_id in self.layer_registry[layer_name]:
                 # we've previously encountered the annotation from a reference
                 annotation = self.layer_registry[layer_name][annotation_id]
             else:
-                annotation = annotation_type(id=annotation_id)
+                annotation = annotation_type()
+                annotation.id = annotation_id
 
             # now fill out fields
             for field in obj['_fields']:
@@ -173,17 +207,15 @@ class SpandexJsonDecoder(json.JSONDecoder):
                     valstr = field['value']
                     val = None if valstr == "null" else int(valstr)
                     setattr(annotation, name, val)
-                elif name in ['scope']:
-                    val = jemtypes.AnnotationScope.from_str(field['value'])
-                    setattr(annotation, name, val)
                 elif name in annotation_type.__dataclass_fields__:
-                    setattr(annotation, name, self.object_hook(field['value']))
+                    field_value = self.decode_obj(field['value'], inside_field=True)
+                    setattr(annotation, name, field_value)
 
             return annotation
 
         elif obj_type == 'annotation_ref':
             layer_name = obj['_annotation_type']
-            ref_id = uuid.UUID(obj['ref']['id'])
+            ref_id = obj['ref']['id']
             if ref_id in self.layer_registry[layer_name]:
                 annotation = self.layer_registry[layer_name][ref_id]
             else:
@@ -193,4 +225,6 @@ class SpandexJsonDecoder(json.JSONDecoder):
                 annotation = annotation_type(id=ref_id)
                 self.layer_registry[layer_name][ref_id] = annotation
             annotation_ref = jemtypes.AnnotationRef(obj=annotation)
+            if inside_field:
+                return annotation
             return annotation_ref

--- a/jembatan/core/spandex/typesys_base.py
+++ b/jembatan/core/spandex/typesys_base.py
@@ -1,13 +1,17 @@
-from dataclasses import dataclass, field
+from collections import deque
+from dataclasses import dataclass, field, Field
 from functools import total_ordering
-from typing import Generic, Iterable, TypeVar, Union
+from typing import get_type_hints, Any, Generic, Iterable, List, Mapping, Optional, Sequence, TypeVar, Union
 
+import bson
 import enum
+import itertools
 import math
-import uuid
+import typing
+import typing_inspect
 
 
-@dataclass
+@dataclass(repr=False)
 @total_ordering
 class Span:
     """
@@ -86,10 +90,7 @@ class AnnotationScope(enum.Enum):
     SPAN = "SPAN"
 
     def to_json(self):
-        return {
-            '_type': "spandex_annotation_scope",
-            'value': self.value
-        }
+        return self.value
 
     def __lt__(self, other: "AnnotationScope"):
         ordering = [self.UNKNOWN, self.DOCUMENT, self.SPAN]
@@ -103,11 +104,46 @@ class AnnotationScope(enum.Enum):
             return AnnotationScope.UNKNOWN
 
 
-@dataclass
+class AnnotationMeta(type):
+    """
+    Metaclass used to define special construction of Annotation types.
+    """
+
+    @classmethod
+    def create_post(metacls, scope):
+        def __post_init__(self):
+            self._scope = scope
+        return __post_init__
+
+    def __new__(metacls, name, bases, namespace, **kwds):
+        # Create a new class type
+        newclass = super().__new__(metacls, name, bases, dict(namespace))
+
+        # attach a post init method to initialize scope
+        if 'scope' in kwds:
+            setattr(newclass, '__post_init__', AnnotationMeta.create_post(kwds['scope']))
+
+        # now wrap the new class in a dataclass
+        dataclass(repr=False)(newclass)
+        return newclass
+
+
+def generate_annotation_id():
+    # For now using bson to align with possible mongo db integration
+    return str(bson.ObjectId())
+
+
 @total_ordering
-class Annotation:
-    id: uuid.UUID = field(default_factory=uuid.uuid4)
-    scope: AnnotationScope = AnnotationScope.UNKNOWN
+class Annotation(metaclass=AnnotationMeta, scope=AnnotationScope.UNKNOWN):
+    id: str = field(default_factory=generate_annotation_id)
+
+    # Define fields that get special status in the __repr__ command
+    _SPECIAL_FIELDS = ['id']
+
+    @property
+    def scope(self) -> AnnotationScope:
+        # FIXME should this go in the metaclass?
+        return self._scope
 
     def __lt__(self, other: "Annotation"):
         if not isinstance(other, Annotation):
@@ -117,17 +153,52 @@ class Annotation:
             return self.id < other.id
         return self.scope < other.scope
 
+    @property
+    def index_key(self):
+        return (self.scope, None)
 
-@dataclass
-class DocumentAnnotation(Annotation):
-    scope: AnnotationScope.SPAN = AnnotationScope.DOCUMENT
+    def encode_field_val_for_repr(self, val):
+        """
+        Function for encoding dataclass field values
+        """
+        # FIXME put this in metaclass because Annotation should not know about dataclasses inherently
+        if isinstance(val, Annotation):
+            return f"{val.__class__.__name__}(id={val.id})"
+        elif isinstance(val, Sequence) and not isinstance(val, str):
+            return '[' + ', '.join([self.encode_field_val_for_repr(v) for v in val]) + ']'
+        elif isinstance(val, Mapping):
+            key_val_str = ', '.join(f"{k}: {self.encode_field_val_for_repr(v)}" for k, v in val.items())
+            return '{' + key_val_str + '}'
+        else:
+            return repr(val)
+
+    def __repr__(self):
+        # Compute special encoding. Not using out of the box __repr__ that comes with
+        special_field_val_pairs = (
+            (fieldname, getattr(self, fieldname)) for fieldname in self._SPECIAL_FIELDS
+        )
+        field_val_pairs = (
+            (fieldname, getattr(self, fieldname)) for fieldname in self.__dataclass_fields__
+            if fieldname not in self._SPECIAL_FIELDS
+        )
+        encoded_field_val_pairs = (
+            (f, self.encode_field_val_for_repr(v)) for (f, v) in
+            itertools.chain(special_field_val_pairs, field_val_pairs)
+        )
+        fields_str = ', '.join(f"{f}={v}" for (f, v) in encoded_field_val_pairs)
+
+        return f"{self.__class__.__name__}({fields_str})"
 
 
-@dataclass
+class DocumentAnnotation(Annotation, metaclass=AnnotationMeta, scope=AnnotationScope.DOCUMENT):
+    pass
+
+
 @total_ordering
-class SpannedAnnotation(Annotation, Span):
+class SpannedAnnotation(Annotation, Span, metaclass=AnnotationMeta, scope=AnnotationScope.SPAN):
 
-    scope: AnnotationScope.SPAN = AnnotationScope.SPAN
+    # Define fields that get special status in the __repr__ command
+    _SPECIAL_FIELDS = ['id', 'begin', 'end']
 
     @property
     def span(self):
@@ -154,6 +225,10 @@ class SpannedAnnotation(Annotation, Span):
     def __hash__(self):
         return (self.id, self.begin, self.end).__hash__()
 
+    @property
+    def index_key(self):
+        return (self.scope, self.begin)
+
 
 # Create template Type variable
 T = T = TypeVar('T')
@@ -164,6 +239,9 @@ class AnnotationRef(Generic[T]):
     obj: T = None
 
     def __repr__(self):
+        if self.obj is None:
+            return f"<AnnotationRef[{self.obj}]>"
+
         return f"<AnnotationRef[{self.obj.__class__.__module__}.{self.obj.__class__.__name__}]: {self.obj.id}>"
 
     @classmethod
@@ -201,3 +279,178 @@ class AnnotationRef(Generic[T]):
                 return [v.obj if v is not None else v for v in annotation_refs]
 
         return property(get_ref)
+
+
+def _get_args_chain(cls):
+    """
+    Extracts out DFS ordering of type hint hierarchy.  This gives sufficient information
+    to perform inspection of python field declarations for type hint matching like List[AnnotationRef]
+    when the declarations may be more like List[AnnotationRef[Token]]
+    """
+    arg_chain = []
+    to_process = deque([cls])
+
+    while to_process:
+        curr = to_process.popleft()
+        curr_origin = getattr(curr, '__origin__', curr)
+        arg_chain.append(curr_origin)
+        args = [a for a in getattr(curr, '__args__', [])]
+        to_process.extendleft(reversed(args))
+    return arg_chain
+
+
+def type_match(src_type, tgt_type):
+    """
+    Compares two type hints to see if they overlap.  This does not require exact matches if the target type
+
+    type_match(
+
+    """
+
+    match = False
+    if tgt_type == Any:
+        match = True
+    elif not issubclass(tgt_type.__class__, typing.GenericMeta):
+        # if the target type is not a generic template, see if we have a subclass match
+        match = issubclass(src_type, tgt_type)
+    else:
+        # check classes are the same
+        match = src_type.__class__ == tgt_type.__class__
+
+        if match:
+            src_origin = typing_inspect.get_last_origin(src_type)
+            tgt_origin = typing_inspect.get_last_origin(tgt_type)
+
+            match = typing_inspect.get_origin(Union[src_origin, tgt_origin]) != Union
+
+            #match = src_origin == tgt_origin
+
+    if not match:
+        return False
+
+    src_args = typing_inspect.get_last_args(src_type)
+    tgt_args = typing_inspect.get_last_args(tgt_type)
+
+    if len(tgt_args) == 0:
+        return True
+
+    if len(src_args) != len(tgt_args):
+        return False
+
+    for src_arg, tgt_arg in zip(src_args, tgt_args):
+        if not type_match(src_arg, tgt_arg):
+            return False
+
+    return True
+
+
+
+def _create_annot_ref(annot: Annotation) -> Optional[AnnotationRef]:
+
+    """ Convert annotation into AnnotationRef """
+    return AnnotationRef(obj=v) if v is not None else v
+
+
+def _create_deref_prop(attribute_name):
+    """
+    Given an attribute name, this will create a convenience property for getting
+    and setting the underlying annotation for the reference
+    """
+    @property
+    def prop(self) -> Annotation:
+        ref = getattr(self, attribute_name)
+        return ref.obj if ref is not None else ref
+
+    @prop.setter
+    def prop(self, v: Annotation) -> None:
+        setattr(self, attribute_name, _create_annot_ref(v))
+
+    prop.__doc__ = f"""
+    Dereference convenience property for getting/setting contents of {attribute_name} AnnotationRef
+    """
+    return prop
+
+
+def _create_list_deref_prop(attribute_name):
+    """
+    Given an attribute name, this will create a convenience property for getting
+    and setting the underlying annotation for the reference
+    """
+    @property
+    def prop(self) -> Annotation:
+        refs = getattr(self, attribute_name)
+
+        if refs is None:
+            return []
+        else:
+            return [ref.obj if ref is not None else ref for ref in refs]
+
+    @prop.setter
+    def prop(self, values: List[Annotation]) -> None:
+        if values is not None:
+            setattr(self, attribute_name, [_create_annot_ref(v) for v in values])
+        else:
+
+            setattr(self, attribute_name, [])
+
+    prop.__doc__ = f"""
+    Dereference convenience property for getting/setting List of AnnotationRefs in {attribute_name}
+    """
+    return prop
+
+
+def make_it_annotation(cls):
+    """
+    Decorator that coverts class into an annotation.
+
+
+    Examples:
+
+    @SpandexAnnotation
+    class MyAnnotation:
+        value: int = 1
+
+        previous_annot_ref: AnnotationRef["MyAnnotation"] = None
+    """
+
+    # parse out class definition
+    # look for annotations of type AnnotationRef
+    ref_suffix = '_ref'
+    ref_plural_suffix = '_refs'
+    for attribute_name, attribute in get_type_hints(cls).items():
+        print(attribute)
+
+        try:
+            attr = getattr(cls, attribute_name)
+        except AttributeError:
+            raise AttributeError(
+                f"Annotation field {attribute_name} does not have a valid default value.  "
+                "Refer to :func:`~dataclasses.field` for more information.")
+        prop_name = None
+        prop_is_list = False
+        if attribute == AnnotationRef:
+            if isinstance(attr, Field) and 'deref_prop_name' in attr.metadata:
+                # If field metadata specifies property name, use that
+                prop_name = attr.metadata['deref_prop_name']
+            elif attribute_name.endswith(ref_suffix):
+                # Back off to convention of naming by dropping ref
+                prop_name = attribute_name[:-len(ref_suffix)]
+
+        elif _get_args_chain(attribute)[0:2] == [List, AnnotationRef]:
+            prop_is_list = True
+            if isinstance(attr, Field) and 'deref_prop_name' in attr.metadata:
+                # If field metadata specifies property name, use that
+                prop_name = attr.metadata['deref_prop_name']
+            elif attribute_name.endswith(ref_plural_suffix):
+                # Back off to convention of naming by dropping ref
+                prop_name = attribute_name[:-len(ref_plural_suffix)]
+
+        if prop_name:
+            create_func = _create_list_deref_prop if prop_is_list else _create_deref_prop
+            prop = create_func(attribute_name)
+            setattr(cls, prop_name, prop)
+
+    # convert it into a dataclass
+    dataclass(cls)
+
+    return cls

--- a/jembatan/core/spandex/typesys_base.py
+++ b/jembatan/core/spandex/typesys_base.py
@@ -115,6 +115,13 @@ class AnnotationMeta(type):
             self._scope = scope
         return __post_init__
 
+    @classmethod
+    def create_scope_property(metacls):
+        def scope(self):
+            return self._scope
+
+        return property(scope)
+
     def __new__(metacls, name, bases, namespace, **kwds):
         # Create a new class type
         newclass = super().__new__(metacls, name, bases, dict(namespace))
@@ -122,6 +129,7 @@ class AnnotationMeta(type):
         # attach a post init method to initialize scope
         if 'scope' in kwds:
             setattr(newclass, '__post_init__', AnnotationMeta.create_post(kwds['scope']))
+            setattr(newclass, 'scope', AnnotationMeta.create_scope_property())
 
         # now wrap the new class in a dataclass
         dataclass(repr=False)(newclass)
@@ -139,11 +147,6 @@ class Annotation(metaclass=AnnotationMeta, scope=AnnotationScope.UNKNOWN):
 
     # Define fields that get special status in the __repr__ command
     _SPECIAL_FIELDS = ['id']
-
-    @property
-    def scope(self) -> AnnotationScope:
-        # FIXME should this go in the metaclass?
-        return self._scope
 
     def __lt__(self, other: "Annotation"):
         if not isinstance(other, Annotation):

--- a/jembatan/core/spandex/typesys_base.py
+++ b/jembatan/core/spandex/typesys_base.py
@@ -1,7 +1,7 @@
 from collections import deque
-from dataclasses import dataclass, field, Field
+from dataclasses import dataclass, field
 from functools import total_ordering
-from typing import get_type_hints, Any, Generic, Iterable, List, Mapping, Optional, Sequence, TypeVar, Union
+from typing import get_type_hints, Any, Generic, Iterable, List, Mapping, Optional, Sequence, Tuple, TypeVar, Union
 
 import bson
 import enum
@@ -28,18 +28,18 @@ class Span:
     end: int = None
 
     @property
-    def topair(self):
+    def topair(self) -> Tuple[int, int]:
         return (self.begin, self.end)
 
     @property
-    def isempty(self):
+    def isempty(self) -> bool:
         return self.end == self.begin
 
     @property
     def length(self) -> int:
         return self.end - self.begin
 
-    def contains(self, pos: int):
+    def contains(self, pos: int) -> bool:
         return pos >= self.begin and pos < self.end
 
     def crosses(self, other: "Span") -> bool:
@@ -72,14 +72,14 @@ class Span:
     def __hash__(self):
         return (self.begin, self.end).__hash__()
 
-    def to_json(self):
+    def to_json(self) -> dict:
         return self._asdict()
 
-    def spanned_text(self, spndx: "Spandex"):
+    def spanned_text(self, spndx: "Spandex") -> str:
         return spndx.spanned_text(self)
 
     @classmethod
-    def from_json(self, obj):
+    def from_json(self, obj: dict) -> "Span":
         return Span(**obj)
 
 
@@ -111,7 +111,7 @@ class AnnotationMeta(type):
     """
 
     @classmethod
-    def create_post_fn(metacls, scope):
+    def create_post_fn(metacls, scope: str):
         """
         Factory function for creating a __post_init__ method that is used in conjunction w/ dataclass __init__
         """
@@ -204,12 +204,12 @@ class Annotation(metaclass=AnnotationMeta,
                  scope=AnnotationScope.UNKNOWN,
                  special_fields=['id']):
     """
-    Base class for defining Annotations.  In most cases a new type will not inherit from
-    this one
+    Base class for defining Annotations.  In most cases a new type will not inherit from this one
     """
+    # define base ID field
     id: str = field(default_factory=generate_annotation_id)
 
-    def __lt__(self, other: "Annotation"):
+    def __lt__(self, other: "Annotation") -> bool:
         if not isinstance(other, Annotation):
             return NotImplemented
 
@@ -218,7 +218,7 @@ class Annotation(metaclass=AnnotationMeta,
         return self.scope < other.scope
 
     @property
-    def index_key(self):
+    def index_key(self) -> Tuple[AnnotationScope, Union[int, None]]:
         """
         value used for indexing within Spandex layers
         """
@@ -251,7 +251,7 @@ class SpannedAnnotation(Annotation, Span,
         self.begin = span.begin
         self.end = span.end
 
-    def __lt__(self, other: Union[Span, "SpannedAnnotation", Annotation]):
+    def __lt__(self, other: Union[Span, "SpannedAnnotation", Annotation]) -> bool:
         if isinstance(other, Span):
             span1 = Span(self.begin, self.end)
             span2 = Span(other.begin, other.end)
@@ -268,7 +268,7 @@ class SpannedAnnotation(Annotation, Span,
         return (self.id, self.begin, self.end).__hash__()
 
     @property
-    def index_key(self):
+    def index_key(self) -> Tuple[AnnotationScope, Union[int, None]]:
         return (self.scope, self.begin)
 
 

--- a/jembatan/core/spandex/typesys_base.py
+++ b/jembatan/core/spandex/typesys_base.py
@@ -1,5 +1,7 @@
 from collections import deque
 from dataclasses import dataclass, field
+from dataclasses_json import dataclass_json
+
 from functools import total_ordering
 from typing import get_type_hints, Any, Generic, Iterable, List, Mapping, Optional, Sequence, Tuple, TypeVar, Union
 
@@ -12,6 +14,7 @@ import typing_inspect
 
 
 @dataclass(repr=False)
+@dataclass_json
 @total_ordering
 class Span:
     """

--- a/jembatan/pipeline/__init__.py
+++ b/jembatan/pipeline/__init__.py
@@ -1,0 +1,48 @@
+from typing import AnyStr, Iterable
+
+from jembatan.core.spandex import Spandex
+
+
+class SimplePipeline:
+    """
+    Class wrapping common functions for processing document collections
+    """
+
+    @classmethod
+    def iterate(cls, collection: Iterable[Spandex], stages: Iterable):
+        """
+        Process CAS collection
+        Iterator over processed CASes.  Useful if you want to work with the CAS objects beyond just
+        processing the pipeline.  This is one way to instrument collection of results for evaluation
+        without putting it into your pipeline.
+
+        """
+        for spndx in collection:
+            for stage in stages:
+                stage.process(spndx)
+            yield spndx
+
+    @classmethod
+    def iterate_by_stage(cls, collection: Iterable[Spandex], stages: Iterable):
+        for i, spndx in enumerate(collection):
+            path = []
+            for stage in stages:
+                path.append(str(stage))
+                stage.process(spndx)
+                yield i, '/'.join(path), spndx
+
+    @classmethod
+    def run(cls, collection: Iterable[Spandex], stages: Iterable):
+        """
+        Simply executes the pipeline
+        """
+        for cas in cls.iterate(collection, stages):
+            pass
+
+        for stage in stages:
+            # allow annotators to do cleanup
+            try:
+                getattr(stage, 'collect_process_complete')
+            except AttributeError:
+                return
+            stage.collection_process_complete()

--- a/jembatan/pipeline/__init__.py
+++ b/jembatan/pipeline/__init__.py
@@ -1,4 +1,4 @@
-from typing import AnyStr, Iterable
+from typing import Iterable
 
 from jembatan.core.spandex import Spandex
 
@@ -11,8 +11,8 @@ class SimplePipeline:
     @classmethod
     def iterate(cls, collection: Iterable[Spandex], stages: Iterable):
         """
-        Process CAS collection
-        Iterator over processed CASes.  Useful if you want to work with the CAS objects beyond just
+        Process Spandex collection
+        Iterator over processed Spandexes.  Useful if you want to work with the Spandex objects beyond just
         processing the pipeline.  This is one way to instrument collection of results for evaluation
         without putting it into your pipeline.
 
@@ -34,15 +34,15 @@ class SimplePipeline:
     @classmethod
     def run(cls, collection: Iterable[Spandex], stages: Iterable):
         """
-        Simply executes the pipeline
+        Executes a linear pipeline of stages and runs collection_process_complete on those stages
         """
-        for cas in cls.iterate(collection, stages):
+        for spndx in cls.iterate(collection, stages):
             pass
 
         for stage in stages:
             # allow annotators to do cleanup
             try:
                 getattr(stage, 'collect_process_complete')
+                stage.collection_process_complete()
             except AttributeError:
-                return
-            stage.collection_process_complete()
+                pass

--- a/jembatan/readers/urireader.py
+++ b/jembatan/readers/urireader.py
@@ -1,14 +1,9 @@
 import urllib.request
-from jembatan.core.spandex import Spandex
-from ccgnlp import utils
-from ccgnlp import constants
-
-URI_VIEW = "_UriView"
-
+from jembatan.core.spandex import Spandex, constants
 
 def uri_to_spndx(uri, viewname=None):
     if not viewname:
-        viewname = constants.DEFAULT_VIEW
+        viewname = constants.SPANDEX_DEFAULT_VIEW
     url = urllib.request.urlparse(uri)
     fh = open(uri) if not url.scheme else urllib.request.urlopen(uri)
 
@@ -30,25 +25,22 @@ class UriSpandexCollection:
     def __iter__(self):
         for uri in self.uris:
             spndx = Spandex()
-            view = utils.get_or_create_view(spndx, URI_VIEW)
-            view.content_string = uri
-            view.content_mime = "text/uri"
-
+            view = spndx.create_view(constants.SPANDEX_URI_VIEW, content_string=uri, content_mime="text/uri")
             yield spndx
 
 
 class UriToPlainTextAnalyzer:
 
     def __init__(self, tgt_viewname=None):
-        self.tgt_viewname = tgt_viewname if tgt_viewname else constants.DEFAULT_VIEW
+        self.tgt_viewname = tgt_viewname if tgt_viewname else constants.SPANDEX_DEFAULT_VIEW
         pass
 
     def process(self, spndx):
-        uri_view = spndx.get_view(URI_VIEW)
+        uri_view = spndx.get_view(constants.SPANDEX_URI_VIEW)
 
-        uri = uri_view.sofa_string
+        uri = uri_view.content_string
         url = urllib.request.urlparse(uri)
         fh = open(uri) if not url.scheme else urllib.request.urlopen(uri)
         tgt_view = spndx.get_or_create_view(self.tgt_viewname)
-        tgt_view.sofa_string = fh.read()
-        tgt_view.sofa_mime = "text/plain"
+        tgt_view.content_string = fh.read()
+        tgt_view.content_mime = "text/plain"

--- a/jembatan/typesys/__init__.py
+++ b/jembatan/typesys/__init__.py
@@ -1,1 +1,2 @@
-from jembatan.core.spandex.typesys_base import Annotation, AnnotationRef
+from jembatan.core.spandex.typesys_base import (
+        Annotation, AnnotationRef, AnnotationScope, DocumentAnnotation, SpannedAnnotation)

--- a/jembatan/typesys/chunking.py
+++ b/jembatan/typesys/chunking.py
@@ -1,9 +1,9 @@
 from dataclasses import dataclass
-from jembatan.typesys import Annotation
+from jembatan.typesys import SpannedAnnotation
 
 
 @dataclass
-class Entity(Annotation):
+class Entity(SpannedAnnotation):
     name: str = None
     salience: str = None
     label: str = None

--- a/jembatan/typesys/chunking.py
+++ b/jembatan/typesys/chunking.py
@@ -2,13 +2,11 @@ from dataclasses import dataclass
 from jembatan.typesys import SpannedAnnotation
 
 
-@dataclass
 class Entity(SpannedAnnotation):
     name: str = None
     salience: str = None
     label: str = None
 
 
-@dataclass
 class NounChunk(Entity):
     pass

--- a/jembatan/typesys/namedentity.py
+++ b/jembatan/typesys/namedentity.py
@@ -1,7 +1,7 @@
-from jembatan.typesys import Annotation
+from jembatan.typesys import SpannedAnnotation
 
 
-class NamedEntity(Annotation):
+class NamedEntity(SpannedAnnotation):
     """
     Named entities refer e.g. to persons, locations, organizations and so on. They often consist of multiple tokens.
 

--- a/jembatan/typesys/namedentity.py
+++ b/jembatan/typesys/namedentity.py
@@ -1,8 +1,6 @@
-from dataclasses import dataclass
 from jembatan.typesys import Annotation
 
 
-@dataclass
 class NamedEntity(Annotation):
     """
     Named entities refer e.g. to persons, locations, organizations and so on. They often consist of multiple tokens.

--- a/jembatan/typesys/segmentation.py
+++ b/jembatan/typesys/segmentation.py
@@ -1,35 +1,28 @@
-from dataclasses import dataclass
 from jembatan.typesys import SpannedAnnotation
 from typing import AnyStr
 
 
-@dataclass
 class Document(SpannedAnnotation):
     """ Top level document type """
     pass
 
 
-@dataclass
 class Block(SpannedAnnotation):
     tag: AnyStr = None
 
 
-@dataclass
 class Heading(SpannedAnnotation):
     tag: AnyStr = None
 
 
-@dataclass
 class Paragraph(SpannedAnnotation):
     pass
 
 
-@dataclass
 class Sentence(SpannedAnnotation):
     pass
 
 
-@dataclass
 class Token(SpannedAnnotation):
     lemma: AnyStr = None
     stem: AnyStr = None

--- a/jembatan/typesys/segmentation.py
+++ b/jembatan/typesys/segmentation.py
@@ -1,36 +1,36 @@
 from dataclasses import dataclass
-from jembatan.typesys import Annotation
+from jembatan.typesys import SpannedAnnotation
 from typing import AnyStr
 
 
 @dataclass
-class Document(Annotation):
+class Document(SpannedAnnotation):
     """ Top level document type """
     pass
 
 
 @dataclass
-class Block(Annotation):
+class Block(SpannedAnnotation):
     tag: AnyStr = None
 
 
 @dataclass
-class Heading(Annotation):
+class Heading(SpannedAnnotation):
     tag: AnyStr = None
 
 
 @dataclass
-class Paragraph(Annotation):
+class Paragraph(SpannedAnnotation):
     pass
 
 
 @dataclass
-class Sentence(Annotation):
+class Sentence(SpannedAnnotation):
     pass
 
 
 @dataclass
-class Token(Annotation):
+class Token(SpannedAnnotation):
     lemma: AnyStr = None
     stem: AnyStr = None
     pos: AnyStr = None

--- a/jembatan/typesys/semantics.py
+++ b/jembatan/typesys/semantics.py
@@ -1,9 +1,8 @@
 from dataclasses import dataclass
-from jembatan.typesys import Annotation
+from jembatan.typesys import SpannedAnnotation
 
 
-@dataclass
-class SemanticArg(Annotation):
+class SemanticArg(SpannedAnnotation):
     """
     Named entities refer e.g. to persons, locations, organizations and so on. They often consist of multiple tokens.
 

--- a/jembatan/typesys/syntax.py
+++ b/jembatan/typesys/syntax.py
@@ -14,12 +14,12 @@ class ConstituencyNode(SpannedAnnotation):
     pass
 
 
-@dataclass
 class DependencyEdge(SpannedAnnotation):
     label: str = None
-    head_ref: AnnotationRef[DependencyNode] = None
-    child_ref: AnnotationRef[DependencyNode] = None
+    head: DependencyNode = None
+    child: DependencyNode = None
 
+    """
     @AnnotationRef.deref_property
     def head(self):
         return self.head_ref
@@ -35,6 +35,7 @@ class DependencyEdge(SpannedAnnotation):
     @child.setter
     def child(self, node: DependencyNode):
         self.child_ref = AnnotationRef(node)
+    """
 
     def to_triple_str(self, spndx):
         head_text = self.head.span.spanned_text(spndx)
@@ -42,48 +43,22 @@ class DependencyEdge(SpannedAnnotation):
         return f"{self.label}({child_text},{head_text})"
 
 
-@dataclass
 class DependencyNode(SpannedAnnotation):
-    token: AnnotationRef[Token] = None
+    token: Token = None
 
-    head_edge_ref: AnnotationRef[DependencyEdge] = None
-    child_edge_refs: List[AnnotationRef[DependencyEdge]] = field(default_factory=list)
-
-    @AnnotationRef.deref_property
-    def head_edge(self):
-        return self.head_edge_ref
-
-    @head_edge.setter
-    def head_edge(self, edge: DependencyEdge):
-        self.head_edge_ref = AnnotationRef(obj=edge)
-
-    def add_child_edge(self, edge: DependencyEdge):
-        self.child_edge_refs.append(AnnotationRef(obj=edge))
-
-    @AnnotationRef.iter_deref_property
-    def child_edges(self):
-        return self.child_edge_refs
+    head_edge: DependencyEdge = None
+    child_edges: List[DependencyEdge] = field(default_factory=list)
 
     @property
     def is_root(self):
         return self.head_edge and self.head_edge.head == self
 
 
-@dataclass
 class DependencyParse(SpannedAnnotation):
-    root_ref: AnnotationRef[DependencyNode] = None
+    root: DependencyNode = None
     flavor: str = "unknown"
 
-    @AnnotationRef.deref_property
-    def root(self):
-        return self.root_ref
 
-    @root.setter
-    def root(self, node: DependencyNode):
-        self.root_ref = AnnotationRef(obj=node)
-
-
-@dataclass
 class ConstituencyNode(SpannedAnnotation):
     token: AnnotationRef[Token] = None
     type_: str = None
@@ -95,7 +70,6 @@ class ConstituencyNode(SpannedAnnotation):
         return not self.children
 
 
-@dataclass
 class ConstituencyParse(SpannedAnnotation):
     """
     Typically Spans the full sentence

--- a/jembatan/typesys/syntax.py
+++ b/jembatan/typesys/syntax.py
@@ -1,6 +1,6 @@
 from collections import deque
-from dataclasses import dataclass, field
-from jembatan.typesys import SpannedAnnotation, AnnotationRef
+from dataclasses import field
+from jembatan.typesys import SpannedAnnotation
 from jembatan.typesys.segmentation import Token
 from typing import List, Iterator
 
@@ -18,24 +18,6 @@ class DependencyEdge(SpannedAnnotation):
     label: str = None
     head: DependencyNode = None
     child: DependencyNode = None
-
-    """
-    @AnnotationRef.deref_property
-    def head(self):
-        return self.head_ref
-
-    @head.setter
-    def head(self, node: DependencyNode):
-        self.head_ref = AnnotationRef(node)
-
-    @AnnotationRef.deref_property
-    def child(self):
-        return self.child_ref
-
-    @child.setter
-    def child(self, node: DependencyNode):
-        self.child_ref = AnnotationRef(node)
-    """
 
     def to_triple_str(self, spndx):
         head_text = self.head.span.spanned_text(spndx)
@@ -60,10 +42,10 @@ class DependencyParse(SpannedAnnotation):
 
 
 class ConstituencyNode(SpannedAnnotation):
-    token: AnnotationRef[Token] = None
+    token: Token = None
     type_: str = None
-    parent: AnnotationRef[ConstituencyNode] = None
-    children: List[AnnotationRef[ConstituencyNode]] = field(default_factory=list)
+    parent: ConstituencyNode = None
+    children: List[ConstituencyNode] = field(default_factory=list)
 
     @property
     def is_leaf(self):
@@ -74,20 +56,12 @@ class ConstituencyParse(SpannedAnnotation):
     """
     Typically Spans the full sentence
     """
-    token_ref: AnnotationRef[Token] = None
+    token: Token = None
     type_: str = None
-    children_refs: List[AnnotationRef[ConstituencyNode]] = field(default_factory=list)
-
-    @AnnotationRef.deref_property
-    def token(self):
-        return self.token_ref
-
-    @AnnotationRef.iter_deref_property
-    def children(self):
-        return self.children_refs
+    children: List[ConstituencyNode] = field(default_factory=list)
 
     def add_child(self, node: ConstituencyNode):
-        self.children_refs.append(node)
+        self.children.append(node)
 
     def __iter__(self, depth_first=True) -> Iterator[ConstituencyNode]:
 

--- a/jembatan/typesys/syntax.py
+++ b/jembatan/typesys/syntax.py
@@ -1,21 +1,21 @@
 from collections import deque
 from dataclasses import dataclass, field
-from jembatan.typesys import Annotation, AnnotationRef
+from jembatan.typesys import SpannedAnnotation, AnnotationRef
 from jembatan.typesys.segmentation import Token
 from typing import List, Iterator
 
 
 # Placeholder before redefining below
-class DependencyNode(Annotation):
+class DependencyNode(SpannedAnnotation):
     pass
 
 
-class ConstituencyNode(Annotation):
+class ConstituencyNode(SpannedAnnotation):
     pass
 
 
 @dataclass
-class DependencyEdge(Annotation):
+class DependencyEdge(SpannedAnnotation):
     label: str = None
     head_ref: AnnotationRef[DependencyNode] = None
     child_ref: AnnotationRef[DependencyNode] = None
@@ -43,7 +43,7 @@ class DependencyEdge(Annotation):
 
 
 @dataclass
-class DependencyNode(Annotation):
+class DependencyNode(SpannedAnnotation):
     token: AnnotationRef[Token] = None
 
     head_edge_ref: AnnotationRef[DependencyEdge] = None
@@ -70,7 +70,7 @@ class DependencyNode(Annotation):
 
 
 @dataclass
-class DependencyParse(Annotation):
+class DependencyParse(SpannedAnnotation):
     root_ref: AnnotationRef[DependencyNode] = None
     flavor: str = "unknown"
 
@@ -84,7 +84,7 @@ class DependencyParse(Annotation):
 
 
 @dataclass
-class ConstituencyNode(Annotation):
+class ConstituencyNode(SpannedAnnotation):
     token: AnnotationRef[Token] = None
     type_: str = None
     parent: AnnotationRef[ConstituencyNode] = None
@@ -96,7 +96,7 @@ class ConstituencyNode(Annotation):
 
 
 @dataclass
-class ConstituencyParse(Annotation):
+class ConstituencyParse(SpannedAnnotation):
     """
     Typically Spans the full sentence
     """

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(name='jembatan',
       install_requires=[
           "spacy",
           "dataclasses",
+          "dataclasses-json",
           "typing_inspect"
       ],
       test_require=[

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,8 @@ setup(name='jembatan',
       packages=find_packages(),
       install_requires=[
           "spacy",
-          "dataclasses"
+          "dataclasses",
+          "typing_inspect"
       ],
       test_require=[
           "pytest"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import pytest
 import spacy
+from jembatan.typesys import Annotation, SpannedAnnotation, AnnotationRef
 
 
 @pytest.yield_fixture(scope="function")

--- a/tests/test_spandex.py
+++ b/tests/test_spandex.py
@@ -1,10 +1,7 @@
 from bson import ObjectId
 from dataclasses import dataclass
-from jembatan.analyzers import simple
-from jembatan.readers.textreader import text_to_spandex
-from jembatan.typesys.segmentation import Sentence, Token
-from jembatan.typesys import Annotation, AnnotationRef, DocumentAnnotation, SpannedAnnotation
 from jembatan.core.spandex import Span, Spandex
+from jembatan.typesys import Annotation, DocumentAnnotation, SpannedAnnotation
 
 
 @dataclass
@@ -92,6 +89,9 @@ def test_spandex():
         for foo in foos:
             foo.spanned_text(spndx) == '567'
             spndx.spanned_text(foo) == '567'
+
+        foos = spndx.select_covered(FooSpanAnnotation, Span(bar.begin, bar.end))
+        assert len(foos) == 10
 
     blahs = spndx.select(BlahDocAnnotation)
     assert len(blahs) == 2

--- a/tests/test_spandex.py
+++ b/tests/test_spandex.py
@@ -1,43 +1,51 @@
 from bson import ObjectId
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from jembatan.core.spandex import Span, Spandex
-from jembatan.typesys import Annotation, DocumentAnnotation, SpannedAnnotation
+from jembatan.core.spandex import json as spandex_json
+from jembatan.typesys import Annotation, AnnotationScope, DocumentAnnotation, SpannedAnnotation
+from typing import List
+
+import json
 
 
-@dataclass
 class FooSpanAnnotation(SpannedAnnotation):
     prop1: int = 0
     prop2: str = "foo"
+    prev: "FooSpanAnnotation" = None
+    double_prev: List["FooSpanAnnotation"] = field(default_factory=list)
 
 
-@dataclass
 class BarSpanAnnotation(SpannedAnnotation):
     prop_a: int = "a"
     prop_b: str = "b"
 
 
-@dataclass
 class BlahDocAnnotation(DocumentAnnotation):
     prop_c: int = 42
 
 
 ANNOTATION_IDS = [
-    ObjectId('5d657267b2870f18471ad12e'),
-    ObjectId('5d657267b2870f18471ad12f'),
-    ObjectId('5d657267b2870f18471ad130'),
-    ObjectId('5d657267b2870f18471ad131'),
-    ObjectId('5d657267b2870f18471ad132'),
-    ObjectId('5d657267b2870f18471ad133'),
-    ObjectId('5d657267b2870f18471ad134')
+    str(ObjectId('5d657267b2870f18471ad12e')),
+    str(ObjectId('5d657267b2870f18471ad12f')),
+    str(ObjectId('5d657267b2870f18471ad130')),
+    str(ObjectId('5d657267b2870f18471ad131')),
+    str(ObjectId('5d657267b2870f18471ad132')),
+    str(ObjectId('5d657267b2870f18471ad133')),
+    str(ObjectId('5d657267b2870f18471ad134'))
 ]
 
 
 def test_typesys():
 
+    assert Annotation().scope == AnnotationScope.UNKNOWN
+    assert SpannedAnnotation().scope == AnnotationScope.SPAN
+    assert DocumentAnnotation().scope == AnnotationScope.DOCUMENT
+
     # note we are forcing ANNOTATION_IDS for consistent testcase ordering
     foo1 = FooSpanAnnotation(id=ANNOTATION_IDS[0])
     assert foo1.prop1 == 0
     assert foo1.prop2 == "foo"
+    assert foo1.scope == AnnotationScope.SPAN
 
     foo2 = FooSpanAnnotation(id=ANNOTATION_IDS[1], begin=10, end=15)
 
@@ -50,8 +58,12 @@ def test_typesys():
     assert bar1 != bar2
 
     blah1 = BlahDocAnnotation(id=ANNOTATION_IDS[4])
+    assert blah1.scope == AnnotationScope.DOCUMENT
+    doc1 = DocumentAnnotation()
+    assert doc1.scope == AnnotationScope.DOCUMENT
 
     unknown = Annotation(id=ANNOTATION_IDS[5])
+    assert unknown.scope == AnnotationScope.UNKNOWN
 
     expected_order = [unknown, blah1, foo1, bar1, bar2, foo2]
     actual_order = sorted([foo1, bar1, bar2, foo2, blah1, unknown])
@@ -95,3 +107,47 @@ def test_spandex():
 
     blahs = spndx.select(BlahDocAnnotation)
     assert len(blahs) == 2
+
+
+def test_serialization():
+    content_string = ''.join(str(s % 10) for s in range(100))
+    spndx = Spandex(content_string=content_string)
+
+    # make Foos cover all character offsets with range 5-8
+    prev = None
+    for i in range(50):
+        begin = i * 10 + 5
+        end = i*10 + 8
+        foo = FooSpanAnnotation(begin=begin, end=end)
+        foo.prev = prev
+        foo.double_prev.append(prev)
+        foo.double_prev.append(prev)
+        spndx.add_annotations(FooSpanAnnotation, foo)
+        prev = foo
+
+    # make Bars cover spans of 100 characters
+    for i in range(5):
+        begin = i * 100
+        end = begin + 100
+        spndx.add_annotations(BarSpanAnnotation, BarSpanAnnotation(begin=begin, end=end))
+
+    # make blah Document level annotations
+    blah1 = BlahDocAnnotation()
+    blah2 = BlahDocAnnotation()
+    spndx.add_annotations(BlahDocAnnotation, blah1, blah2)
+
+    spndx_in = spndx
+
+    print("serializing")
+    serialized_spndx_str = json.dumps(spndx_in, cls=spandex_json.SpandexJsonEncoder)
+
+    from pprint import pprint
+    #pprint(json.loads(serialized_spndx_str))
+
+    spndx_out = json.loads(serialized_spndx_str, cls=spandex_json.SpandexJsonDecoder)
+    pprint(spndx_out.annotations)
+
+    for foo in spndx_out.select(FooSpanAnnotation):
+        print(foo.prev)
+
+

--- a/tests/test_spandex.py
+++ b/tests/test_spandex.py
@@ -1,0 +1,97 @@
+from bson import ObjectId
+from dataclasses import dataclass
+from jembatan.analyzers import simple
+from jembatan.readers.textreader import text_to_spandex
+from jembatan.typesys.segmentation import Sentence, Token
+from jembatan.typesys import Annotation, AnnotationRef, DocumentAnnotation, SpannedAnnotation
+from jembatan.core.spandex import Span, Spandex
+
+
+@dataclass
+class FooSpanAnnotation(SpannedAnnotation):
+    prop1: int = 0
+    prop2: str = "foo"
+
+
+@dataclass
+class BarSpanAnnotation(SpannedAnnotation):
+    prop_a: int = "a"
+    prop_b: str = "b"
+
+
+@dataclass
+class BlahDocAnnotation(DocumentAnnotation):
+    prop_c: int = 42
+
+
+ANNOTATION_IDS = [
+    ObjectId('5d657267b2870f18471ad12e'),
+    ObjectId('5d657267b2870f18471ad12f'),
+    ObjectId('5d657267b2870f18471ad130'),
+    ObjectId('5d657267b2870f18471ad131'),
+    ObjectId('5d657267b2870f18471ad132'),
+    ObjectId('5d657267b2870f18471ad133'),
+    ObjectId('5d657267b2870f18471ad134')
+]
+
+
+def test_typesys():
+
+    # note we are forcing ANNOTATION_IDS for consistent testcase ordering
+    foo1 = FooSpanAnnotation(id=ANNOTATION_IDS[0])
+    assert foo1.prop1 == 0
+    assert foo1.prop2 == "foo"
+
+    foo2 = FooSpanAnnotation(id=ANNOTATION_IDS[1], begin=10, end=15)
+
+    assert foo1 == foo1
+    assert foo1 < foo2
+
+    bar1 = BarSpanAnnotation(id=ANNOTATION_IDS[2])
+    bar2 = BarSpanAnnotation(id=ANNOTATION_IDS[3], prop_a="A", prop_b="B", begin=5, end=9)
+
+    assert bar1 != bar2
+
+    blah1 = BlahDocAnnotation(id=ANNOTATION_IDS[4])
+
+    unknown = Annotation(id=ANNOTATION_IDS[5])
+
+    expected_order = [unknown, blah1, foo1, bar1, bar2, foo2]
+    actual_order = sorted([foo1, bar1, bar2, foo2, blah1, unknown])
+
+    for expected, actual in zip(expected_order, actual_order):
+        assert expected.id == actual.id
+
+
+def test_spandex():
+    content_string = ''.join(str(s % 10) for s in range(500))
+    spndx = Spandex(content_string=content_string)
+
+    # make Foos cover all character offsets with range 5-8
+    for i in range(50):
+        begin = i * 10 + 5
+        end = i*10 + 8
+        spndx.add_annotations(FooSpanAnnotation, FooSpanAnnotation(begin=begin, end=end))
+
+    # make Bars cover spans of 100 characters
+    for i in range(5):
+        begin = i * 100
+        end = begin + 100
+        spndx.add_annotations(BarSpanAnnotation, BarSpanAnnotation(begin=begin, end=end))
+
+    # make blah Document level annotations
+    blah1 = BlahDocAnnotation()
+    blah2 = BlahDocAnnotation()
+    spndx.add_annotations(BlahDocAnnotation, blah1)
+    spndx.add_annotations(BlahDocAnnotation, blah2)
+
+    for bar in spndx.select(BarSpanAnnotation):
+        foos = spndx.select_covered(FooSpanAnnotation, bar)
+        assert len(foos) == 10
+
+        for foo in foos:
+            foo.spanned_text(spndx) == '567'
+            spndx.spanned_text(foo) == '567'
+
+    blahs = spndx.select(BlahDocAnnotation)
+    assert len(blahs) == 2

--- a/tests/test_spandex.py
+++ b/tests/test_spandex.py
@@ -152,6 +152,9 @@ def test_serialization():
             foo.spanned_text(spndx) == '567'
             spndx.spanned_text(foo) == '567'
 
+            assert isinstance(foo.seq_prop, list)
+            assert isinstance(foo.map_prop, dict)
+
         foos = spndx.select_covered(FooSpanAnnotation, Span(bar.begin, bar.end))
         assert len(foos) == 10
 


### PR DESCRIPTION
This started as a way to include and serialize view (document-level) annotations, then expanded so that the API made a more consistent interface.


Much of the rewrite was for removing AnnotationRefs from type system authoring. Previously making links in new Annotation types required using AnnotationRefs. This was done for serialization convenience, but it made for a clumsier API experience.  Now you can declare your type system however you want.

Along the way I’ve introduced the notion of scope and SpannedAnnotation and DocumentAnnotation.  These allow us to index them in the spandex all in one area instead of separate management.

This process is pretty involved and at its core, base annotation types are now produced via a meta class, so that the details of its data class usage are less and do not require explicit decoration in each new class.