### PR TITLE
Feature/alter spndx view hierarchy

### DIFF
--- a/jembatan/analyzers/simple.py
+++ b/jembatan/analyzers/simple.py
@@ -1,6 +1,7 @@
-from jembatan.core.af import AnalysisFunction
-from jembatan.core.spandex import Span, Spandex
+from jembatan.core.af import process_default_view, AnalysisFunction
+from jembatan.core.spandex import JembatanDoc, Span, Spandex
 from jembatan.typesys import Annotation
+from jembatan.typesys.segmentation import Token
 from typing import Pattern
 
 import re
@@ -23,7 +24,8 @@ class RegexMatchAnnotator(AnalysisFunction):
         self.annotation_type = annotation_type
         self.window_type = window_type
 
-    def process(self, spndx: Spandex):
+    @process_default_view
+    def process(self, spndx: Spandex, **kwargs):
         if self.window_type:
             windows = [window.span for window in spndx.select(self.window_type)]
         else:
@@ -59,7 +61,8 @@ class RegexSplitAnnotator(AnalysisFunction):
         self.annotation_type = annotation_type
         self.window_type = window_type
 
-    def process(self, spndx: Spandex):
+    @process_default_view
+    def process(self, spndx: Spandex, **kwargs):
         if self.window_type:
             windows = [window.span for window in spndx.select(self.window_type)]
         else:
@@ -98,11 +101,10 @@ class RegexSplitAnnotator(AnalysisFunction):
 
 class SimpleTokenizer:
     def __init__(self, window_type=None):
-        from jembatan.typesys.segmentation import Token
-        self.regex_annotator = RegexMatchAnnotator(re.compile("\w+"), Token, window_type=window_type)
+        self.regex_annotator = RegexMatchAnnotator(re.compile(r'\w+'), Token, window_type=window_type)
 
-    def process(self, spndx):
-        self.regex_annotator.process(spndx)
+    def process(self, jemdoc: JembatanDoc):
+        self.regex_annotator.process(jemdoc)
 
 
 class SimpleSentenceSegmenter:
@@ -111,5 +113,5 @@ class SimpleSentenceSegmenter:
         self.regex_annotator = RegexMatchAnnotator(
             re.compile(re.compile(r'[^\s\.][^\.]+')), Sentence, window_type=window_type)
 
-    def process(self, spndx):
-        self.regex_annotator.process(spndx)
+    def process(self, jemdoc: JembatanDoc):
+        self.regex_annotator.process(jemdoc)

--- a/jembatan/analyzers/spacy.py
+++ b/jembatan/analyzers/spacy.py
@@ -1,12 +1,10 @@
 import re
-#from jembatan.spandex import (Span, Spandex)
-#from ..spandex.types import (Document, Sentence, Token, PartOfSpeech, NounChunk, DependencyEdge, Entity)
 import itertools
 import functools
 
 from enum import auto, Flag
 from jembatan.core.spandex import (Span, Spandex)
-from jembatan.core.af import AnalysisFunction
+from jembatan.core.af import process_default_view, AnalysisFunction
 from jembatan.typesys.chunking import NounChunk, Entity
 from jembatan.typesys.segmentation import (Document, Sentence, Token)
 from jembatan.typesys.syntax import (DependencyEdge, DependencyNode, DependencyParse)
@@ -265,7 +263,8 @@ class SpacyAnalyzer(AnalysisFunction):
 
         self.window_type = window_type
 
-    def process(self, spndx, **kwargs):
+    @process_default_view
+    def process(self, spndx: Spandex, **kwargs):
         """
         Args:
             **kwargs: Keyword Arguments
@@ -281,7 +280,9 @@ class SpacyAnalyzer(AnalysisFunction):
                 by subsection boundaries  Default of None means to process the
                 full contents of the Spandex.
         """
-        #window_type = kwargs.get('window_type', None)
+
+        # FIXME, better in init or as kwargs?
+        # window_type = kwargs.get('window_type', None)
         annotation_layers = kwargs.get('annotation_layers', AnnotationLayers.ALL())
 
         if not self.window_type:

--- a/jembatan/core/af/__init__.py
+++ b/jembatan/core/af/__init__.py
@@ -1,61 +1,77 @@
+from functools import wraps
 from typing import Dict, Optional, Union
 import jembatan.core.spandex as spandex
+
+
+def process_default_view(f):
+    """
+    For single-view analysis functions it's often easier to define manipulations in terms
+    of the view/spandex object instead of having to get the view from the parent jem object
+    """
+    @wraps(f)
+    def process_wrapper(self, jemdoc: spandex.JembatanDoc, *args, **kwds):
+        spndx = jemdoc.default_view
+        return f(self, spndx, **kwds)
+    return process_wrapper
+
 
 class AnalysisFunction(object):
     """
     Base annotator class for processing Spandex objects. This is provided as a convenience
     for object-oriented development of annotators.  By virtue of python duck-typing
-    any function that accepts a Spandex object or any class that overrides 
+    any function that accepts a Spandex object or any class that overrides
     __call__(self, spndx) will work as well.
     """
 
-    def process(self, spndx, **kwargs):
+    def process(self, jemdoc: spandex.JembatanDoc, **kwargs):
         """
-        Override this method to define Annotator behavior.  Typically this is used to add annotation or data to the Spandex object.
+        Override this method to define Annotator behavior.  Typically this is used to add annotation or data to the
+        Spandex object.
 
         Args:
-            spndx(:obj:`Spandex`) - Spandex object to process
-            **kwargs - Arbitrary keyword arguments.  These are typically 
+            jemdoc(:obj:`JembatanDoc`) - JembatanDoc object to process
+            **kwargs - Arbitrary keyword arguments.  These are typically
                 defined per AnalysisFunction.  Use these to inject behavior
                 changes that can not be accounted for during initialization
         """
         pass
 
-
-    def __call__(self, spndx, **kwargs):
+    def __call__(self, jemdoc: spandex.JembatanDoc, **kwargs):
         """ Processes Spandex object.  In most cases this should not be 
         overridden.  Instead subclasses should override the `process` method.
-        
+
         Args:
-            spndx(:obj:`Spandex`) - Spandex object to process
-            **kwargs - Arbitrary keyword arguments.  These are typically 
+            jemdoc(:obj:`JembatanDoc`) - JembatanDoc object to process
+            **kwargs - Arbitrary keyword arguments.  These are typically
                 defined per AnalysisFunction.  Use these to inject behavior
                 changes that can not be accounted for during initialization
-       
+
         """
-        self.process(spndx, **kwargs)
+        self.process(jemdoc, **kwargs)
 
 
 class AggregateAnalysisFunction(AnalysisFunction):
-    """ A 'simple' class for pipelining annotators which serially process a Spandex object.
+    """ A 'simple' class for orchestrating annotators which serially process a JembatanDoc object.
 
-    Beyond simply passing the same Spandex between annotators, 
-    `AggregateAnalysisFunction` has support for mapping of view names.  
-    This allows annotators which operate in specific views to be reused on 
-    different views without need for re-instantiating or re-configuring 
-    the annotator.  A common use case is running tokenization on
-    a Gold and Test view of the data.
+    Beyond simply passing the same JembatanDoc between annotators,
+    `AggregateAnalysisFunction` has support for mapping of view names.
+    This allows annotators which operate in specific views to be reused on
+    different views without need for re-instantiating or re-configuring
+    the annotator.  This allows for reuse of components that operate over specific view names.
+    The most common use case is for running single view components, which process the default view
+    on alternative views.
+
+    Consider a tokenizer that runs on the default view. For our pipeline we actually need it to run
+    on Gold and Test views of our JembatanDoc container.
 
     Usage:
-
         # for the sake of example assume:
-        # 1. spandex has been initialized with text in views named "gold", "test" 
-        # as well as the default view
-        # 2. sentence_annotator is a function or functor that accepts and directly
-        # manipulates the spandex it is given without retrieving other views
+        # 1. spandex has been initialized with text in views named "gold", "test".
+        # 2. sentence_annotator is a single-view function or functor that accepts a jembatan and only
+        #    manipulates the default view without retrieving other views
 
-        # load/initialize spandex
-        spndx = ...
+        # load/initialize jembatan
+        jemdoc = ...
 
         agg_pipeline = AggregateAnalysisFunction()
 
@@ -68,46 +84,46 @@ class AggregateAnalysisFunction(AnalysisFunction):
         # annotate sentences on the test view
         agg_pipeline.add(sentence_annotator, {spandex.constants.SPANDEX_DEFAULT_VIEW: "test"})
 
-        # run the pipeline on a spandex doc
-        agg_pipeline(spndx)
+        # run the pipeline on a the jembatan doc
+        agg_pipeline(jemdoc)
 
     """
 
-
     def __init__(self):
-        """ create empty Aggregate Annotator 
+        """
+        Create empty Aggregate Annotator
         """
         self.annotators = []
         self.view_maps = []
         self.af_kwargs_list = []
 
-    def add(self, analysis_func: AnalysisFunction, view_map:Optional[Dict[str, str]]=None, **kwargs):
+    def add(self, analysis_func: AnalysisFunction, view_map: Optional[Dict[str, str]]=None, **kwargs):
         """ Add analysis function to pipeline
 
         Args:
             analysis func(:obj:) a function or an object with
-                '__call__(spndx, **kwargs)' implemented.
+                '__call__(jemdoc, **kwargs)' implemented.
                 An analysis function accepts and processes a Spandex object
-                view_map (dict, optional): A dictionary mapping between the 
-                views used internally by the analysis function and the views present in 
+                view_map (dict, optional): A dictionary mapping between the
+                views used internally by the analysis function and the views present in
                 the spandex.  Defaults of None indicates not to do mapping.
 
-            **kwargs: extra parameters to pass to analysis function.process() to allow 
-                for change in runtime behavior separate from remapping of view 
-                names.  These are intended to allow for reuse of components 
+            **kwargs: extra parameters to pass to analysis function.process() to allow
+                for change in runtime behavior separate from remapping of view
+                names.  These are intended to allow for reuse of components
                 without need to initialize a new object.
         """
         self.annotators.append(analysis_func)
         self.view_maps.append(view_map)
         self.af_kwargs_list.append(kwargs)
 
-    def process(self, spndx, **kwargs):
+    def process(self, jemdoc: spandex.JembatanDoc, **kwargs):
         """
         Runs the aggregate analysis function (pipeline) defined through calls
         to the `add` method.
 
         Args:
-            spndx (:obj:`Spandex`): Spandex object to process
+            jemdoc (:obj:`Spandex`): JembatanDoc document object to process
 
             **kwargs: Arbitrary keyword arguments.  Not currently used
         """
@@ -117,16 +133,8 @@ class AggregateAnalysisFunction(AnalysisFunction):
                 enumerate(zip(self.annotators, self.view_maps, self.af_kwargs_list)):
 
             if view_map:
-                mapped_spndx = spandex.ViewMappedSpandex(spndx, view_map)
+                mapped_jemdoc = spandex.ViewMappedJembatanDoc(jemdoc, view_map)
             else:
-                mapped_spndx = spndx
+                mapped_jemdoc = jemdoc
 
-            # Always pass the mapped default view into the annotator
-            # This way functions/methods that just run on what is passed
-            # can do so without having to call get_view themselves
-            try:
-                mapped_view = mapped_spndx.get_view(spandex.constants.SPANDEX_DEFAULT_VIEW)
-            except KeyError:
-                mapped_view = mapped_spndx
-            annotator(mapped_view, **af_kwargs)
-
+            annotator(mapped_jemdoc, **af_kwargs)

--- a/jembatan/core/af/views.py
+++ b/jembatan/core/af/views.py
@@ -1,44 +1,33 @@
-from collections import namedtuple
 from jembatan.core.af import AnalysisFunction
+from jembatan.core.spandex import JembatanDoc
+
 
 class ViewCreator(AnalysisFunction):
-    """ This annotator can be placed at/near the beginning of a pipeline to 
-    ensure that a particular view  is created before it is used further 
-    downstream. It will create a view for the view name specified at 
-    construction.  If it doesn't exist. 
-    
-    One place this is useful is if you are using an annotator that uses the 
-    default view and you have mapped the default view into a different view 
-    via a mapping.  The default view is created automatically - but if you 
-    have mapped the default view to some other view, then the view provided to 
-    your annotator (when it asks for the default view) will not be created 
+    """ This annotator can be placed at/near the beginning of a pipeline to
+    ensure that a particular view  is created before it is used further
+    downstream. It will create a view for the view name specified at
+    construction.  If it doesn't exist.
+
+    One place this is useful is if you are using an annotator that uses the
+    default view and you have mapped the default view into a different view
+    via a mapping.  The default view is created automatically - but if you
+    have mapped the default view to some other view, then the view provided to
+    your annotator (when it asks for the default view) will not be created
     unless you have explicitly created it.
     """
 
-    def __init__(self, viewname):
-        self.viewname = viewname
-
-    def process(self, spndx, **kwargs):
-        self.create_view_safely(spndx, self.viewname)
+    def process(self, jemdoc: JembatanDoc, viewname, **kwargs):
+        self.create_view_safely(jemdoc, viewname)
 
     @classmethod
-    def create_view_safely(cls, spndx, viewname):
-        spndx.create_view(viewname, None)
-    
+    def create_view_safely(cls, jemdoc: JembatanDoc, viewname: str):
+        jemdoc.create_view(viewname)
+
 
 class ViewTextCopier(AnalysisFunction):
-    Constants = namedtuple(
-        "ViewTextCopierConstants", 
-        ["DEFAULT_SOURCE_VIEW", "DEFAULT_TARGET_VIEW"])
 
-    constants = Constants("_viewTextCopierDefaultSourceView", "_viewTextCopierDefaultTargetView")
-
-    def __init__(self, src_viewname=None, tgt_viewname=None):
-        self.src_viewname = src_viewname if src_viewname else self.constants.DEFAULT_SOURCE_VIEW
-        self.tgt_viewname = tgt_viewname if tgt_viewname else self.constants.DEFAULT_TARGET_VIEW
-
-    def process(self, spndx, **kwargs):
-
-        srcview = spndx[self.src_viewname]
-        tgtview = spndx[self.tgt_viewname]
-        tgtview.content = srcview.content
+    def process(self, jemdoc: JembatanDoc, src_viewname, tgt_viewname, **kwargs):
+        srcview = jemdoc.get_view(src_viewname)
+        tgtview = jemdoc.get_view(tgt_viewname)
+        tgtview.content_string = srcview.content_string
+        tgtview.content_mime = srcview.content_mime

--- a/jembatan/core/spandex/__init__.py
+++ b/jembatan/core/spandex/__init__.py
@@ -53,22 +53,6 @@ class Spandex(object):
     def annotations(self):
         return self._annotations
 
-    #def get_view(self, viewname: str):
-    #    return self.viewops.get_view(self, viewname)
-    #
-    #def get_or_create_view(self, viewname: str):
-    #    try:
-    #        view = self.get_view(viewname)
-    #    except KeyError:
-    #        view = self.create_view(viewname)
-    #    return view
-    #
-    #def __getitem__(self, viewname: str):
-    #    return self.get_view(viewname)
-    #
-    #def create_view(self, viewname: str, content_string: str=None, content_mime: str=None):
-    #    return self.viewops.create_view(self, viewname, content_string=content_string, content_mime=content_mime)
-
     def compute_keys(self, layer_annotations: Iterable[Annotation]):
         return [a.index_key for a in layer_annotations]
 

--- a/jembatan/core/spandex/__init__.py
+++ b/jembatan/core/spandex/__init__.py
@@ -268,5 +268,8 @@ class ViewMappedJembatanDoc(object):
 
         return ViewMappedSpandex(view, parent=self)
 
+    def __getitem__(self, viewname: str) -> Spandex:
+        return self.get_view(viewname)
+
 
 __all__ = ['errors', 'encoders']

--- a/jembatan/core/spandex/__init__.py
+++ b/jembatan/core/spandex/__init__.py
@@ -7,64 +7,6 @@ from pathlib import Path
 from typing import ClassVar, Dict, Iterable, Optional, Union
 
 
-class DefaultViewOps(object):
-    """
-    Defines behaviors we can perform on a view.  This is intended to be used for the root (default) Spandex that
-    governs all views
-    """
-
-    def __init__(self):
-        pass
-
-    def get_view(self, spndx, viewname: str):
-
-        root = spndx.root
-
-        view = None
-
-        try:
-            view = root.views[viewname]
-        except KeyError as e:
-            raise KeyError("No view named '{}' in Spandex {}".format(viewname, root))
-
-        return view
-
-    def create_view(self, spndx: "Spandex", viewname: str, content_string: str=None, content_mime: str=None):
-        root = spndx if not spndx.root else spndx.root
-
-        new_view_spndx = Spandex(content_string=content_string, content_mime=content_mime, root=root, viewname=viewname)
-        if viewname in root.views:
-            raise KeyError("View {} already exists in Spandex{}".format(viewname, root))
-        root.views[viewname] = new_view_spndx
-        return new_view_spndx
-
-
-class ViewMappedViewOps(DefaultViewOps):
-    """
-    Overrides ViewOps by resolving view names by way of a view_map
-
-    This is the mechanism that allows us to say, run this analysis that normally
-    runs on view X and instead run it on view Y.
-    """
-    def __init__(self, view_map: Dict[str, str]=None):
-        self.view_map = view_map or {}
-
-    def get_view(self, spndx: "Spandex", viewname: str):
-        # Attempt to map view from given view map.  If none exists, pass through the unmappped view name
-        mapped_viewname = self.view_map.get(viewname, viewname)
-        return super(ViewMappedViewOps, self).get_view(spndx, mapped_viewname)
-
-    def create_view(self, root_spndx: "Spandex", viewname: str, content_string: str=None, content_mime: str=None):
-        """
-
-        """
-        mapped_viewname = self.view_map[viewname]
-        return super(ViewMappedViewOps, self).create_view(root_spndx,
-                                                          viewname=mapped_viewname,
-                                                          content_string=content_string,
-                                                          content_mime=content_mime)
-
-
 SpandexConstants = namedtuple("SpandexContstants", ["SPANDEX_DEFAULT_VIEW", "SPANDEX_URI_VIEW"])
 
 constants = SpandexConstants("_SpandexDefaultView", "_SpandexUriView")
@@ -73,73 +15,59 @@ constants = SpandexConstants("_SpandexDefaultView", "_SpandexUriView")
 # object is mutable for performant reasons
 class Spandex(object):
     """
-    Spandex - data structure for holding views of data, its content, and annotations
+    Spandex - data structure for holding a view of data, its content, and annotations
     """
 
-    def __init__(self, content_string: str=None, content_mime: str = None, root=None, viewname=None):
+    def __init__(self, parent: "Jembatan", content_string: str=None, content_mime: str = None, viewname=None):
+        self._parent = parent
         self._content_string = content_string
         self._content_mime = content_mime
         self._annotations = []
         self._annotation_keys = []
-        self.viewops = DefaultViewOps()
-
-        if not root:
-            self.viewname = constants.SPANDEX_DEFAULT_VIEW
-            self._views = {
-                constants.SPANDEX_DEFAULT_VIEW: self
-            }
-            self.root = self
-        else:
-            self.viewname = viewname
-            self._views = None
-            self.root = root
+        self.viewname = viewname
 
     def __repr__(self):
         return "<{}/{} at 0x{:x}>".format(self.__class__.__name__, self.viewname, id(self))
 
     @property
-    def is_root(self):
-        return self.root == self
+    def parent(self) -> "JembatanDoc":
+        return self._parent
 
     @property
-    def views(self):
-        return self.root._views
-
-    @property
-    def content_string(self):
+    def content_string(self) -> str:
         return self._content_string
 
     @content_string.setter
-    def content_string(self, value):
+    def content_string(self, value: str):
         self._content_string = value
 
     @property
-    def content_mime(self):
+    def content_mime(self) -> str:
         return self._content_mime
 
     @content_mime.setter
-    def content_mime(self, value):
+    def content_mime(self, value: str):
         self._content_mime = value
 
     @property
     def annotations(self):
         return self._annotations
 
-    def get_view(self, viewname: str):
-        return self.viewops.get_view(self, viewname)
-
-    def get_or_create_view(self, viewname: str):
-        try:
-            view = self.get_view(viewname)
-        except KeyError:
-            view.create_view(viewname)
-        return view
-
-    def __getitem__(self, viewname: str):
-        return self.get_view(viewname)
-
-    def create_view(self, viewname: str, content_string: str=None, content_mime: str=None):
-        return self.viewops.create_view(self, viewname, content_string=content_string, content_mime=content_mime)
+    #def get_view(self, viewname: str):
+    #    return self.viewops.get_view(self, viewname)
+    #
+    #def get_or_create_view(self, viewname: str):
+    #    try:
+    #        view = self.get_view(viewname)
+    #    except KeyError:
+    #        view = self.create_view(viewname)
+    #    return view
+    #
+    #def __getitem__(self, viewname: str):
+    #    return self.get_view(viewname)
+    #
+    #def create_view(self, viewname: str, content_string: str=None, content_mime: str=None):
+    #    return self.viewops.create_view(self, viewname, content_string=content_string, content_mime=content_mime)
 
     def compute_keys(self, layer_annotations: Iterable[Annotation]):
         return [a.index_key for a in layer_annotations]
@@ -219,43 +147,73 @@ class Spandex(object):
             raise TypeError("`path` needs to be one of [str, None, Path], but was <{0}>".format(type(path)))
 
 
-class ViewMappedSpandex(object):
+class JembatanDoc(object):
+    """
+    Top level container for processing.  The JembatanDoc roughly describes /manages a document or artifact.
+    It is responsible for managing views.
+    """
 
-    def __init__(self, wrapped_spandex, view_map):
-        """
-        Wraps a Spandex object so we can override its view names for use by
-        an analysis function
+    def __init__(self, metadata: Dict=None, content_string: str=None, content_mime: str=None):
+        self.metadata = metadata
+        self._views = {}
 
-        Args:
-        wrapped_spandex (Spandex) - The original Spandex which we want to inject
-            a view mapping
-        view_map (dict) - A map between the names used by the
-            analyzer function and the names specified by the pipeline
-        """
-        self._wrapped_spandex = wrapped_spandex
-        self.viewops = ViewMappedViewOps(view_map)
+        self.create_view(
+            constants.SPANDEX_DEFAULT_VIEW,
+            content_string=content_string,
+            content_mime=content_mime,
+        )
 
     @property
-    def content(self):
-        return self._wrapped_spandex._content_string
+    def default_view(self):
+        return self.get_view(constants.SPANDEX_DEFAULT_VIEW)
 
-    @content.setter
-    def content(self, value):
-        self._wrapped_spandex._content_string = value
+    def get_view(self, viewname: str):
+        view = None
 
-    def get_view(self, viewname):
-        view = self.viewops.get_view(self._wrapped_spandex, viewname)
-        return ViewMappedSpandex(view, self.viewops)
+        try:
+            view = self.views[viewname]
+        except KeyError as e:
+            raise KeyError("No view named '{}' in Jembatan {}".format(viewname, self))
+
+        return view
+
+    def get_or_create_view(self, viewname: str):
+        try:
+            view = self.get_view(viewname)
+        except KeyError:
+            view = self.create_view(viewname)
+        return view
 
     def __getitem__(self, viewname: str):
         return self.get_view(viewname)
 
     def create_view(self, viewname: str, content_string: str=None, content_mime: str=None):
-        view = self.viewops.create_view(self._wrapped_spandex,
-                                        viewname,
-                                        content_string=content_string,
-                                        content_mime=content_mime)
-        return ViewMappedSpandex(view, self.viewops)
+
+        if viewname in self.views:
+            raise KeyError("View {} already exists in Jembatan{}".format(viewname, self))
+
+        new_view_spndx = Spandex(content_string=content_string, content_mime=content_mime, parent=self, viewname=viewname)
+        self.views[viewname] = new_view_spndx
+        return new_view_spndx
+
+    @property
+    def views(self):
+        return self._views
+
+
+class ViewMappedSpandex(object):
+
+    def __init__(self, spandex: Spandex, view_mapped_parent: JembatanDoc):
+        '''
+        Wrapper constructor.
+        @param obj: object to wrap
+        '''
+        # wrap the object
+        self._wrapped_spandex = spandex
+        self._wrapped_parent = view_mapped_parent
+
+        if view_mapped_parent.wrapped != self.wrapped.parent:
+            raise ValueError("Can not wrap parent from different Jembatans")
 
     def __getattr__(self, attr):
         # see if this object has attr
@@ -264,9 +222,67 @@ class ViewMappedSpandex(object):
         if attr in self.__dict__:
             # this object has it
             return getattr(self, attr)
-
         # proxy to the wrapped object
-        return getattr(self._wrapped_spandex, attr)
+        return getattr(self.wrapped, attr)
+
+    def __repr__(self):
+        return "<{}/{} at 0x{:x}>".format(self.__class__.__name__, self.viewname, id(self))
+
+    @property
+    def wrapped(self):
+        return self._wrapped_spandex
+
+    @property
+    def parent(self):
+        return self._wrapped_parent
+
+
+class ViewMappedJembatanDoc(object):
+    '''
+    Object wrapper class.
+    This a wrapper for objects. It is initialiesed with the object to wrap
+    and then proxies the unhandled getattribute methods to it.
+    Other classes are to inherit from it.
+    '''
+    def __init__(self, jemdoc: JembatanDoc, view_map):
+        '''
+        Wrapper constructor.
+        @param obj: object to wrap
+        '''
+        # wrap the object
+        self._wrapped_jemdoc = jemdoc
+        self.view_map = view_map
+
+    def __getattr__(self, attr):
+        # see if this object has attr
+        # NOTE do not use hasattr, it goes into
+        # infinite recurrsion
+        if attr in self.__dict__:
+            # this object has it
+            return getattr(self, attr)
+        # proxy to the wrapped object
+        return getattr(self._wrapped_jemdoc, attr)
+
+    @property
+    def wrapped(self):
+        return self._wrapped_jemdoc
+
+    def get_view(self, viewname):
+        mapped_viewname = self.view_map[viewname]
+        view = self.wrapped.get_view(mapped_viewname)
+
+        # we need to wrap the view so that if it references its parent it can get back to the ViewMapped version
+        # instead of the original one
+        return ViewMappedSpandex(view, self)
+
+    def create_view(self, viewname):
+        if viewname in self.view_map:
+            mapped_viewname = self.view_map[viewname]
+            view = self.wrapped.create_view(mapped_viewname)
+        else:
+            view = self.wrapped.create_view(viewname)
+
+        return ViewMappedSpandex(view, parent=self)
 
 
 __all__ = ['errors', 'encoders']

--- a/jembatan/core/spandex/json.py
+++ b/jembatan/core/spandex/json.py
@@ -15,7 +15,7 @@ SPANDEX_TYPE_STR = "spandex"
 SPANDEX_ANNOTATION_TYPE_STR = "spandex_annotation"
 
 
-class JembatanJsonEncoder(json.JSONEncoder):
+class JembatanDocJsonEncoder(json.JSONEncoder):
 
     def default(self, obj):
         return self.encode_obj(obj)
@@ -107,7 +107,7 @@ class JembatanJsonEncoder(json.JSONEncoder):
         return json.JSONEncoder.default(self, obj)
 
 
-class JembatanJsonDecoder(json.JSONDecoder):
+class JembatanDocJsonDecoder(json.JSONDecoder):
     def __init__(self, *args, **kwargs):
         json.JSONDecoder.__init__(self, object_hook=self.object_hook, *args, **kwargs)
         self.reset_layers()

--- a/jembatan/pipeline/__init__.py
+++ b/jembatan/pipeline/__init__.py
@@ -1,6 +1,6 @@
 from typing import Iterable
 
-from jembatan.core.spandex import Spandex
+from jembatan.core.spandex import Jembatan
 
 
 class SimplePipeline:
@@ -9,7 +9,7 @@ class SimplePipeline:
     """
 
     @classmethod
-    def iterate(cls, collection: Iterable[Spandex], stages: Iterable):
+    def iterate(cls, collection: Iterable[Jembatan], stages: Iterable):
         """
         Process Spandex collection
         Iterator over processed Spandexes.  Useful if you want to work with the Spandex objects beyond just
@@ -17,26 +17,26 @@ class SimplePipeline:
         without putting it into your pipeline.
 
         """
-        for spndx in collection:
+        for jemdoc in collection:
             for stage in stages:
-                stage.process(spndx)
-            yield spndx
+                stage.process(jemdoc)
+            yield jemdoc
 
     @classmethod
-    def iterate_by_stage(cls, collection: Iterable[Spandex], stages: Iterable):
-        for i, spndx in enumerate(collection):
+    def iterate_by_stage(cls, collection: Iterable[Jembatan], stages: Iterable):
+        for i, jemdoc in enumerate(collection):
             path = []
             for stage in stages:
                 path.append(str(stage))
-                stage.process(spndx)
-                yield i, '/'.join(path), spndx
+                stage.process(jemdoc)
+                yield i, '/'.join(path), jemdoc
 
     @classmethod
-    def run(cls, collection: Iterable[Spandex], stages: Iterable):
+    def run(cls, collection: Iterable[Jembatan], stages: Iterable):
         """
         Executes a linear pipeline of stages and runs collection_process_complete on those stages
         """
-        for spndx in cls.iterate(collection, stages):
+        for jemdoc in cls.iterate(collection, stages):
             pass
 
         for stage in stages:

--- a/jembatan/pipeline/__init__.py
+++ b/jembatan/pipeline/__init__.py
@@ -1,6 +1,6 @@
 from typing import Iterable
 
-from jembatan.core.spandex import Jembatan
+from jembatan.core.spandex import JembatanDoc
 
 
 class SimplePipeline:
@@ -9,7 +9,7 @@ class SimplePipeline:
     """
 
     @classmethod
-    def iterate(cls, collection: Iterable[Jembatan], stages: Iterable):
+    def iterate(cls, collection: Iterable[JembatanDoc], stages: Iterable):
         """
         Process Spandex collection
         Iterator over processed Spandexes.  Useful if you want to work with the Spandex objects beyond just
@@ -23,7 +23,7 @@ class SimplePipeline:
             yield jemdoc
 
     @classmethod
-    def iterate_by_stage(cls, collection: Iterable[Jembatan], stages: Iterable):
+    def iterate_by_stage(cls, collection: Iterable[JembatanDoc], stages: Iterable):
         for i, jemdoc in enumerate(collection):
             path = []
             for stage in stages:
@@ -32,7 +32,7 @@ class SimplePipeline:
                 yield i, '/'.join(path), jemdoc
 
     @classmethod
-    def run(cls, collection: Iterable[Jembatan], stages: Iterable):
+    def run(cls, collection: Iterable[JembatanDoc], stages: Iterable):
         """
         Executes a linear pipeline of stages and runs collection_process_complete on those stages
         """

--- a/jembatan/readers/textreader.py
+++ b/jembatan/readers/textreader.py
@@ -1,15 +1,15 @@
-from jembatan.core.spandex import Spandex
+from jembatan.core.spandex import JembatanDoc
 
 
-def text_to_spandex(text):
+def text_to_jembatan_doc(text):
     """
-    Create unadorned plaintext cas
+    Create Jembatan with text populating default view
     """
-    spndx = Spandex(content_string=text, content_mime="text/plain")
-    return spndx
+    jem = JembatanDoc(content_string=text, content_mime="text/plain")
+    return jem
 
 
-class TextSpandexCollection():
+class TextJemdocCollection():
     """
     Given collection of texts transform into collection of Spandexes
     """
@@ -22,7 +22,4 @@ class TextSpandexCollection():
 
     def __iter__(self):
         for text in self.texts:
-            yield text_to_spandex(text)
-
-
-
+            yield text_to_jembatan_doc(text)

--- a/jembatan/utils/__init__.py
+++ b/jembatan/utils/__init__.py
@@ -1,0 +1,25 @@
+from jembatan.core.af import AnalysisFunction
+from jembatan.core.spandex import Spandex
+
+
+def copy_view(spndx: Spandex, src_viewname: str, tgt_viewname: str):
+    src_view = spndx.get_view(src_viewname)
+    tgt_view = spndx.get_or_create_view(tgt_viewname)
+
+    tgt_view.content_string = src_view.content_string
+    tgt_view.content_mime = src_view.content_mime
+
+    return tgt_view
+
+
+class ViewCopier(AnalysisFunction):
+    """
+    Wraps copy_view function in an AnalysisFunction
+    """
+
+    def __init__(self, src_viewname: str, tgt_viewname: str):
+        self.src_viewname = src_viewname
+        self.tgt_viewname = tgt_viewname
+
+    def process(self, spndx):
+        copy_view(spndx, self.src_viewname, self.tgt_viewname)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 spacy>=2.0.0,<3.0.0
 https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-2.1.0/en_core_web_sm-2.1.0.tar.gz#egg=en_core_web_sm
-
+dataclasses==0.6
+dataclasses-json==0.3.2
+bson==0.5.8
+typing_inspect

--- a/tests/test_jembatan.py
+++ b/tests/test_jembatan.py
@@ -1,0 +1,24 @@
+from jembatan.core.spandex import JembatanDoc, ViewMappedJembatanDoc
+from jembatan.core.spandex import constants as jemconst
+
+
+def test_viewmapped_wrappers():
+    default_view_content = "This is the default view content"
+    jem = JembatanDoc(metadata="metadata", content_string=default_view_content)
+
+    other_view_content = "This is the mapped default view content"
+    other_viewname = "Other"
+    other_view = jem.create_view(viewname=other_viewname, content_string=other_view_content)
+
+    view_map = {
+        jemconst.SPANDEX_DEFAULT_VIEW: other_viewname
+    }
+
+    mapped_jem = ViewMappedJembatanDoc(jem, view_map)
+
+    assert other_view == jem.get_view(other_viewname)
+
+    mapped_view = mapped_jem.get_view(jemconst.SPANDEX_DEFAULT_VIEW)
+    assert other_view == mapped_view.wrapped
+
+    assert other_view.content_string == mapped_view.content_string

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -1,26 +1,29 @@
 from jembatan.analyzers import simple
-from jembatan.readers.textreader import text_to_spandex
+from jembatan.core.spandex import constants as jemconst
+from jembatan.readers.textreader import text_to_jembatan_doc
 from jembatan.typesys.segmentation import Sentence, Token
 
 
 def test_simple_tokenizer(sample_texts):
 
     text = "This has four words"
-    cas = text_to_spandex(text)
+    jemdoc = text_to_jembatan_doc(text)
 
     tokenizer = simple.SimpleTokenizer()
-    tokenizer.process(cas)
+    tokenizer.process(jemdoc)
 
-    tokens = cas.select(Token)
+    spndx = jemdoc.get_view(jemconst.SPANDEX_DEFAULT_VIEW)
+    tokens = spndx.select(Token)
     assert len(list(tokens)) == 4
 
 
 def test_simple_sentence_segmenter():
     text = "This is sentence 1.  This is sentence 2.  This is sentence 3."
-    cas = text_to_spandex(text)
+    jemdoc = text_to_jembatan_doc(text)
 
     segmenter = simple.SimpleSentenceSegmenter()
 
-    segmenter.process(cas)
-    sentences = cas.select(Sentence)
+    spndx = jemdoc.get_view(jemconst.SPANDEX_DEFAULT_VIEW)
+    segmenter.process(jemdoc)
+    sentences = spndx.select(Sentence)
     assert len(list(sentences)) == 3

--- a/tests/test_spacy.py
+++ b/tests/test_spacy.py
@@ -95,9 +95,9 @@ def test_spacy_json_serialization(spacy_pipeline):
 
     spacy_analyzer.process(jemdoc_in)
 
-    serialized_spndx_str = json.dumps(jemdoc_in, cls=spandex_json.JembatanJsonEncoder)
+    serialized_spndx_str = json.dumps(jemdoc_in, cls=spandex_json.JembatanDocJsonEncoder)
 
-    jemdoc_out = json.loads(serialized_spndx_str, cls=spandex_json.JembatanJsonDecoder)
+    jemdoc_out = json.loads(serialized_spndx_str, cls=spandex_json.JembatanDocJsonDecoder)
 
     spndx_in = jemdoc_in.default_view
     sentences_in = spndx_in.select(jemtypes.segmentation.Sentence)

--- a/tests/test_spacy.py
+++ b/tests/test_spacy.py
@@ -1,5 +1,5 @@
 from jembatan.analyzers import spacy as jemspacy
-from jembatan.readers.textreader import text_to_spandex
+from jembatan.readers.textreader import text_to_jembatan_doc
 from jembatan.core.spandex import json as spandex_json
 
 import json
@@ -47,12 +47,13 @@ def test_spacy_dep(spacy_pipeline):
     expected_pos_tags = ['NNP', 'VBD', 'DT', 'NN', 'IN', 'NNP', '.']
     expected_lemmas = ['John', 'give', 'the', 'ball', 'to', 'Mary', '.']
 
-    spndx = text_to_spandex(text)
+    jemdoc = text_to_jembatan_doc(text)
 
     spacy_analyzer = jemspacy.SpacyAnalyzer(spacy_pipeline=spacy_pipeline)
 
-    spacy_analyzer.process(spndx)
+    spacy_analyzer.process(jemdoc)
 
+    spndx = jemdoc.default_view
     # pull out annotations and check values
     tokens = spndx.select(jemtypes.segmentation.Token)
     sentences = spndx.select(jemtypes.segmentation.Sentence)
@@ -88,17 +89,20 @@ def test_spacy_json_serialization(spacy_pipeline):
     expected_pos_tags = ['NNP', 'VBD', 'DT', 'NN', 'IN', 'NNP', '.']
     expected_lemmas = ['john', 'give', 'the', 'ball', 'to', 'mary', '.']
 
-    spndx_in = text_to_spandex(text)
+    jemdoc_in = text_to_jembatan_doc(text)
 
     spacy_analyzer = jemspacy.SpacyAnalyzer(spacy_pipeline=spacy_pipeline)
 
-    spacy_analyzer.process(spndx_in)
+    spacy_analyzer.process(jemdoc_in)
 
-    serialized_spndx_str = json.dumps(spndx_in, cls=spandex_json.SpandexJsonEncoder)
+    serialized_spndx_str = json.dumps(jemdoc_in, cls=spandex_json.JembatanJsonEncoder)
 
-    spndx_out = json.loads(serialized_spndx_str, cls=spandex_json.SpandexJsonDecoder)
+    jemdoc_out = json.loads(serialized_spndx_str, cls=spandex_json.JembatanJsonDecoder)
 
+    spndx_in = jemdoc_in.default_view
     sentences_in = spndx_in.select(jemtypes.segmentation.Sentence)
+
+    spndx_out = jemdoc_out.default_view
     sentences_out = spndx_out.select(jemtypes.segmentation.Sentence)
     assert len(sentences_in) == len(sentences_out)
 

--- a/tests/test_spandex.py
+++ b/tests/test_spandex.py
@@ -1,7 +1,9 @@
 from bson import ObjectId
-from dataclasses import dataclass, field
-from jembatan.core.spandex import Span, Spandex
+from dataclasses import field
+from jembatan.core.spandex import Span
+from jembatan.core.spandex import constants as jemconst
 from jembatan.core.spandex import json as spandex_json
+from jembatan.readers.textreader import text_to_jembatan_doc
 from jembatan.typesys import Annotation, AnnotationScope, DocumentAnnotation, SpannedAnnotation
 from typing import Dict, List
 
@@ -84,7 +86,8 @@ def test_typesys():
 def test_typesys_inheritance():
 
     content_string = ''.join(str(s % 10) for s in range(500))
-    spndx = Spandex(content_string=content_string)
+    jemdoc = text_to_jembatan_doc(content_string)
+    spndx = jemdoc.get_view(jemconst.SPANDEX_DEFAULT_VIEW)
 
     foo = FooSpanAnnotation(begin=100, end=200)
     foo_one = FooOneExtended(begin=200, end=300)
@@ -101,7 +104,8 @@ def test_typesys_inheritance():
 
 def test_spandex():
     content_string = ''.join(str(s % 10) for s in range(500))
-    spndx = Spandex(content_string=content_string)
+    jemdoc = text_to_jembatan_doc(content_string)
+    spndx = jemdoc.get_view(jemconst.SPANDEX_DEFAULT_VIEW)
 
     # make Foos cover all character offsets with range 5-8
     for i in range(50):
@@ -144,7 +148,9 @@ def test_spandex():
 
 def test_serialization():
     content_string = ''.join(str(s % 10) for s in range(100))
-    spndx = Spandex(content_string=content_string)
+
+    jemdoc = text_to_jembatan_doc(content_string)
+    spndx = jemdoc.get_view(jemconst.SPANDEX_DEFAULT_VIEW)
 
     # make Foos cover all character offsets with range 5-8
     prev = None
@@ -170,12 +176,15 @@ def test_serialization():
     blah2 = BlahDocAnnotation()
     spndx.add_annotations(blah1, blah2)
 
-    spndx_in = spndx
+    jemdoc_in = jemdoc
 
-    serialized_spndx_str = json.dumps(spndx_in, cls=spandex_json.SpandexJsonEncoder)
+    serialized_spndx_str = json.dumps(jemdoc_in, cls=spandex_json.JembatanJsonEncoder)
 
     # deserialize spandex and validate
-    spndx_out = json.loads(serialized_spndx_str, cls=spandex_json.SpandexJsonDecoder)
+    jem_out = json.loads(serialized_spndx_str, cls=spandex_json.JembatanJsonDecoder)
+    spndx_out = jem_out.get_view(jemconst.SPANDEX_DEFAULT_VIEW)
+
+    assert len(spndx_out.select(BarSpanAnnotation)) == 5
     for bar in spndx_out.select(BarSpanAnnotation):
         foos = spndx_out.select_covered(FooSpanAnnotation, bar)
         assert len(foos) == 10
@@ -192,5 +201,3 @@ def test_serialization():
 
     blahs = spndx.select(BlahDocAnnotation)
     assert len(blahs) == 2
-
-

--- a/tests/test_spandex.py
+++ b/tests/test_spandex.py
@@ -178,10 +178,10 @@ def test_serialization():
 
     jemdoc_in = jemdoc
 
-    serialized_spndx_str = json.dumps(jemdoc_in, cls=spandex_json.JembatanJsonEncoder)
+    serialized_spndx_str = json.dumps(jemdoc_in, cls=spandex_json.JembatanDocJsonEncoder)
 
     # deserialize spandex and validate
-    jem_out = json.loads(serialized_spndx_str, cls=spandex_json.JembatanJsonDecoder)
+    jem_out = json.loads(serialized_spndx_str, cls=spandex_json.JembatanDocJsonDecoder)
     spndx_out = jem_out.get_view(jemconst.SPANDEX_DEFAULT_VIEW)
 
     assert len(spndx_out.select(BarSpanAnnotation)) == 5


### PR DESCRIPTION
Pretty significant refactor to eliminate the often confusing notion that a Spandex was a view and a document.  It is now more explicit with the addition of `JembatanDoc` which is the root container that manages views of type `Spandex`. 

To support view mapping, the `*ViewOps` classes have been removed and there is now `ViewMappedJembatanDoc` and `ViewMappedSpandex`.  These are used by `AggregateAnalysisFunction` to wrap existing JembanDocs and Spandexes to allow for injection of a view_map dictionary when performing view operations.  This is most often used to override the processing view for single-view functions.

The rest of the changes are largely around updates to get the testcases to pass.